### PR TITLE
feat(RELEASE:913): add loader function to get previous release

### DIFF
--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -22,6 +22,7 @@ const (
 	MatchedReleasePlansContextKey
 	MatchedReleasePlanAdmissionContextKey
 	ProcessingResourcesContextKey
+	PreviousReleaseContextKey
 	ReleaseContextKey
 	ReleasePipelineRunContextKey
 	ReleasePlanAdmissionContextKey
@@ -103,6 +104,14 @@ func (l *mockLoader) GetRelease(ctx context.Context, cli client.Client, name, na
 		return l.loader.GetRelease(ctx, cli, name, namespace)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, ReleaseContextKey, &v1alpha1.Release{})
+}
+
+// GetPreviousRelease returns the resource and error passed as values of the context.
+func (l *mockLoader) GetPreviousRelease(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*v1alpha1.Release, error) {
+	if ctx.Value(PreviousReleaseContextKey) == nil {
+		return l.loader.GetPreviousRelease(ctx, cli, release)
+	}
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, PreviousReleaseContextKey, &v1alpha1.Release{})
 }
 
 // GetRoleBindingFromReleaseStatus returns the resource and error passed as values of the context.

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -126,6 +126,21 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		})
 	})
 
+	When("calling GetPreviousRelease", func() {
+		It("returns the resource and error from the context", func() {
+			previousRelease := &v1alpha1.Release{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: PreviousReleaseContextKey,
+					Resource:   previousRelease,
+				},
+			})
+			resource, err := loader.GetPreviousRelease(mockContext, nil, nil)
+			Expect(resource).To(Equal(previousRelease))
+			Expect(err).To(BeNil())
+		})
+	})
+
 	When("calling GetRoleBindingFromReleaseStatus", func() {
 		It("returns the resource and error from the context", func() {
 			roleBinding := &rbac.RoleBinding{}


### PR DESCRIPTION
 - Added new loader function `GetPreviousRelease` to retrieve the previous release. If no release is found, it returns a not found error.