### PR TITLE
refactor(RELEASE-977): migrate to konflux-ci quay org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # redhat.com/release-service-bundle:$VERSION and redhat.com/release-service-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/redhat-appstudio/release-service
+IMAGE_TAG_BASE ?= quay.io/konflux-ci/release-service
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,5 +18,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
   - name: controller
-    newName: quay.io/redhat-appstudio/release-service
+    newName: quay.io/konflux-ci/release-service
     newTag: next


### PR DESCRIPTION
This commit changes the references to redhat-appstudio/release-service to konflux-ci/release-service as the location for pushing this operator was migrated.