### PR TITLE
Chore(RELEASE-523): Rename ServiceAccount field to ServiceAccountName

### DIFF
--- a/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
@@ -103,7 +103,7 @@ spec:
                     - resolver
                     type: object
                   serviceAccountName:
-                    description: ServiceAccount is the ServiceAccount to use during
+                    description: ServiceAccountName is the ServiceAccount to use during
                       the execution of the Pipeline
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string

--- a/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
@@ -108,7 +108,7 @@ spec:
                     - resolver
                     type: object
                   serviceAccountName:
-                    description: ServiceAccount is the ServiceAccount to use during
+                    description: ServiceAccountName is the ServiceAccount to use during
                       the execution of the Pipeline
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string

--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -251,7 +251,7 @@ func (a *adapter) EnsureManagedPipelineIsProcessed() (controller.OperationResult
 
 		if pipelineRun == nil {
 			// Only create a RoleBinding if a ServiceAccount is specified
-			if roleBinding == nil && resources.ReleasePlanAdmission.Spec.Pipeline.ServiceAccount != "" {
+			if roleBinding == nil && resources.ReleasePlanAdmission.Spec.Pipeline.ServiceAccountName != "" {
 				// This string should probably be a constant somewhere
 				roleBinding, err = a.createRoleBindingForClusterRole("release-pipeline-resource-role", resources.ReleasePlanAdmission)
 				if err != nil {
@@ -399,7 +399,7 @@ func (a *adapter) createManagedPipelineRun(resources *loader.ProcessingResources
 		WithOwner(a.release).
 		WithParamsFromConfigMap(resources.EnterpriseContractConfigMap, []string{"verify_ec_task_bundle"}).
 		WithPipelineRef(resources.ReleasePlanAdmission.Spec.Pipeline.PipelineRef.ToTektonPipelineRef()).
-		WithServiceAccount(resources.ReleasePlanAdmission.Spec.Pipeline.ServiceAccount).
+		WithServiceAccount(resources.ReleasePlanAdmission.Spec.Pipeline.ServiceAccountName).
 		WithTimeouts(&resources.ReleasePlanAdmission.Spec.Pipeline.Timeouts, &a.releaseServiceConfig.Spec.DefaultTimeouts).
 		WithWorkspaceFromVolumeTemplate(
 			os.Getenv("DEFAULT_RELEASE_WORKSPACE_NAME"),
@@ -438,7 +438,7 @@ func (a *adapter) createTenantPipelineRun(releasePlan *v1alpha1.ReleasePlan, sna
 		WithParams(releasePlan.Spec.Pipeline.GetTektonParams()...).
 		WithOwner(a.release).
 		WithPipelineRef(releasePlan.Spec.Pipeline.PipelineRef.ToTektonPipelineRef()).
-		WithServiceAccount(releasePlan.Spec.Pipeline.ServiceAccount).
+		WithServiceAccount(releasePlan.Spec.Pipeline.ServiceAccountName).
 		WithTimeouts(&releasePlan.Spec.Pipeline.Timeouts, &a.releaseServiceConfig.Spec.DefaultTimeouts).
 		WithWorkspaceFromVolumeTemplate(
 			os.Getenv("DEFAULT_RELEASE_WORKSPACE_NAME"),
@@ -475,7 +475,7 @@ func (a *adapter) createRoleBindingForClusterRole(clusterRole string, releasePla
 		Subjects: []rbac.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      releasePlanAdmission.Spec.Pipeline.ServiceAccount,
+				Name:      releasePlanAdmission.Spec.Pipeline.ServiceAccountName,
 				Namespace: releasePlanAdmission.Namespace,
 			},
 		},

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -2078,7 +2078,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 							{Name: "pathInRepo", Value: "my-path"},
 						},
 					},
-					ServiceAccount: "service-account",
+					ServiceAccountName: "service-account",
 					Timeouts: tektonv1.TimeoutFields{
 						Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
 					},

--- a/controllers/releaseplan/adapter_test.go
+++ b/controllers/releaseplan/adapter_test.go
@@ -204,7 +204,7 @@ var _ = Describe("ReleasePlan adapter", Ordered, func() {
 			{Name: "parameter1", Value: "value1"},
 			{Name: "parameter2", Value: "value2"},
 		}
-		parameterizedPipeline.ServiceAccount = "test-account"
+		parameterizedPipeline.ServiceAccountName = "test-account"
 
 		releasePlan := &v1alpha1.ReleasePlan{
 			ObjectMeta: metav1.ObjectMeta{

--- a/tekton/utils/pipeline.go
+++ b/tekton/utils/pipeline.go
@@ -43,10 +43,10 @@ type Pipeline struct {
 	// PipelineRef is the reference to the Pipeline
 	PipelineRef PipelineRef `json:"pipelineRef"`
 
-	// ServiceAccount is the ServiceAccount to use during the execution of the Pipeline
+	// ServiceAccountName is the ServiceAccount to use during the execution of the Pipeline
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +optional
-	ServiceAccount string `json:"serviceAccountName,omitempty"`
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// Timeouts defines the different Timeouts to use in the PipelineRun execution
 	// +optional


### PR DESCRIPTION
This commit updates the 'Pipeline' struct by renaming the 'ServiceAccount' field to 'ServiceAccountName'.

Jira: [Link](https://issues.redhat.com/secure/RapidBoard.jspa?rapidView=19560&projectKey=RELEASE&view=planning&selectedIssue=[RELEASE-523](https://issues.redhat.com//browse/RELEASE-523)&quickFilter=124517&issueLimit=100#)

Changes:
* Renamed 'ServiceAccount' field to 'ServiceAccountName' in the Pipeline struct.
