### PR TITLE
Support email usernames

### DIFF
--- a/api/v1alpha1/webhooks/author/webhook.go
+++ b/api/v1alpha1/webhooks/author/webhook.go
@@ -163,6 +163,7 @@ func (w *Webhook) setAuthorLabel(username string, obj client.Object) {
 // sanitizeLabelValue takes a username and returns it in a form appropriate to use as a label value.
 func (w *Webhook) sanitizeLabelValue(username string) string {
 	author := strings.Replace(username, ":", "_", -1) // Colons disallowed in labels
+	author = strings.Replace(author, "@", ".", 1)     // At sign is disallowed. Support usernames that uses email address.
 
 	if len(author) > metadata.MaxLabelLength {
 		author = string(author)[0:metadata.MaxLabelLength]

--- a/api/v1alpha1/webhooks/author/webhook_test.go
+++ b/api/v1alpha1/webhooks/author/webhook_test.go
@@ -526,5 +526,10 @@ var _ = Describe("Author webhook", Ordered, func() {
 			str := webhook.sanitizeLabelValue("abcdefghijklmnopqrstuvwxyz_abcdefghijklmnopqrstuvwxyz_1234567890")
 			Expect(str).To(Equal("abcdefghijklmnopqrstuvwxyz_abcdefghijklmnopqrstuvwxyz_123456789"))
 		})
+
+		It("should convert @ to .", func() {
+			str := webhook.sanitizeLabelValue("user@konflux-ci.dev")
+			Expect(str).To(Equal("user.konflux-ci.dev"))
+		})
 	})
 })


### PR DESCRIPTION
K8s allows usernames to be in the format of an email address. Changing the the author mutating webhook to support it.

closes https://github.com/konflux-ci/release-service/issues/529