### PR TITLE
fix: ignore gitlint checks for bots

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -13,3 +13,6 @@ line-length=88
 
 [contrib-title-conventional-commits]
 
+[ignore-by-author-name]
+regex=(.*)\[bot\](.*)
+ignore=T1,B1


### PR DESCRIPTION
This commit modifies the gitlint configuration to ignore the max title length and max body line length rules for bot accounts. This should encompass both dependabot commits and red-hat-konflux-bot commits.