### PR TITLE
feat(RELEASE-913): add GetPreviousRelease loader function

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -35,6 +35,16 @@ func SetupComponentCache(mgr ctrl.Manager) error {
 		"spec.application", componentIndexFunc)
 }
 
+// SetupReleaseCache adds a new index field to be able to search Releases by ReleasePlan name.
+func SetupReleaseCache(mgr ctrl.Manager) error {
+	releaseIndexFunc := func(obj client.Object) []string {
+		return []string{obj.(*v1alpha1.Release).Spec.ReleasePlan}
+	}
+
+	return mgr.GetCache().IndexField(context.Background(), &v1alpha1.Release{},
+		"spec.releasePlan", releaseIndexFunc)
+}
+
 // SetupReleasePlanCache adds a new index field to be able to search ReleasePlans by target.
 func SetupReleasePlanCache(mgr ctrl.Manager) error {
 	releasePlanIndexFunc := func(obj client.Object) []string {

--- a/controllers/release/controller.go
+++ b/controllers/release/controller.go
@@ -113,6 +113,9 @@ func (c *Controller) SetupCache(mgr ctrl.Manager) error {
 	if err := cache.SetupComponentCache(mgr); err != nil {
 		return err
 	}
+	if err := cache.SetupReleaseCache(mgr); err != nil {
+		return err
+	}
 
 	// NOTE: Both the release and releaseplan controller need this ReleasePlanAdmission cache. However, it only needs to be added
 	// once to the manager, so only one controller should add it. If it is removed here, it should be added to the ReleasePlan controller.

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -21,6 +21,7 @@ const (
 	EnterpriseContractPolicyContextKey
 	MatchedReleasePlansContextKey
 	MatchedReleasePlanAdmissionContextKey
+	PreviousReleaseContextKey
 	ProcessingResourcesContextKey
 	ReleaseContextKey
 	ReleasePipelineRunContextKey
@@ -95,6 +96,14 @@ func (l *mockLoader) GetMatchingReleasePlans(ctx context.Context, cli client.Cli
 		return l.loader.GetMatchingReleasePlans(ctx, cli, releasePlanAdmission)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, MatchedReleasePlansContextKey, &v1alpha1.ReleasePlanList{})
+}
+
+// GetPreviousRelease returns the resource and error passed as values of the context.
+func (l *mockLoader) GetPreviousRelease(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*v1alpha1.Release, error) {
+	if ctx.Value(PreviousReleaseContextKey) == nil {
+		return l.loader.GetPreviousRelease(ctx, cli, release)
+	}
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, PreviousReleaseContextKey, &v1alpha1.Release{})
 }
 
 // GetRelease returns the resource and error passed as values of the context.

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -111,6 +111,21 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		})
 	})
 
+	When("calling GetPreviousRelease", func() {
+		It("returns the resource and error from the context", func() {
+			release := &v1alpha1.Release{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: PreviousReleaseContextKey,
+					Resource:   release,
+				},
+			})
+			resource, err := loader.GetPreviousRelease(mockContext, nil, release)
+			Expect(resource).To(Equal(release))
+			Expect(err).To(BeNil())
+		})
+	})
+
 	When("calling GetRelease", func() {
 		It("returns the resource and error from the context", func() {
 			release := &v1alpha1.Release{}

--- a/loader/suite_test.go
+++ b/loader/suite_test.go
@@ -110,6 +110,7 @@ var _ = BeforeSuite(func() {
 		defer GinkgoRecover()
 
 		Expect(cache.SetupComponentCache(mgr)).To(Succeed())
+		Expect(cache.SetupReleaseCache(mgr)).To(Succeed())
 		Expect(cache.SetupReleasePlanCache(mgr)).To(Succeed())
 		Expect(cache.SetupReleasePlanAdmissionCache(mgr)).To(Succeed())
 


### PR DESCRIPTION
A new funciton has been added to the loader to be able to get the Release created just before a given Release. This is a key function for the collectors feature.