### PR TITLE
chore: remove lingering deployment code

### DIFF
--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -582,21 +582,6 @@ func (a *adapter) registerProcessingStatus(pipelineRun *tektonv1.PipelineRun) er
 	return nil
 }
 
-// syncResources sync all the resources needed to trigger the deployment of the Release being processed.
-func (a *adapter) syncResources() error {
-	releasePlanAdmission, err := a.loader.GetActiveReleasePlanAdmissionFromRelease(a.ctx, a.client, a.release)
-	if err != nil {
-		return err
-	}
-
-	snapshot, err := a.loader.GetSnapshot(a.ctx, a.client, a.release)
-	if err != nil {
-		return err
-	}
-
-	return a.syncer.SyncSnapshot(snapshot, releasePlanAdmission.Namespace)
-}
-
 // validateAuthor will ensure that a valid author exists for the Release and add it to its status. If the Release
 // has the automated label but doesn't have automated set in its status, this function will return an error so the
 // operation knows to requeue the Release.

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -1498,54 +1498,6 @@ var _ = Describe("Release adapter", Ordered, func() {
 		})
 	})
 
-	When("calling syncResources", func() {
-		var adapter *adapter
-
-		AfterEach(func() {
-			_ = adapter.client.Delete(ctx, adapter.release)
-		})
-
-		BeforeEach(func() {
-			adapter = createReleaseAndAdapter()
-		})
-
-		It("fails if there's no active ReleasePlanAdmission", func() {
-			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
-				{
-					ContextKey: loader.ReleasePlanAdmissionContextKey,
-					Err:        fmt.Errorf("not found"),
-				},
-			})
-
-			Expect(adapter.syncResources()).NotTo(Succeed())
-		})
-
-		It("fails if there's no Snapshot", func() {
-			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
-				{
-					ContextKey: loader.ReleasePlanAdmissionContextKey,
-				},
-				{
-					ContextKey: loader.SnapshotContextKey,
-					Err:        fmt.Errorf("not found"),
-				},
-			})
-
-			Expect(adapter.syncResources()).NotTo(Succeed())
-		})
-
-		It("should sync resources properly", func() {
-			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
-				{
-					ContextKey: loader.ReleasePlanAdmissionContextKey,
-					Resource:   releasePlanAdmission,
-				},
-			})
-
-			Expect(adapter.syncResources()).To(Succeed())
-		})
-	})
-
 	When("calling validateAuthor", func() {
 		var adapter *adapter
 		var conditionMsg string


### PR DESCRIPTION
The deployment related code was removed a while ago. Remove remaining syncResources function.