### PR TITLE
feat(RELEASE-910): add timeout field to collectors

### DIFF
--- a/api/v1alpha1/collectors.go
+++ b/api/v1alpha1/collectors.go
@@ -8,6 +8,10 @@ type Collector struct {
 	// +required
 	Name string `json:"name"`
 
+	// Timeout in seconds for the collector to execute
+	// +optional
+	Timeout int `json:"timeout,omitempty"`
+
 	// Type is the type of collector to be used
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +required

--- a/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplanadmissions.yaml
@@ -82,6 +82,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    timeout:
+                      description: Timeout in seconds for the collector to execute
+                      type: integer
                     type:
                       description: Type is the type of collector to be used
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$

--- a/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseplans.yaml
@@ -80,6 +80,9 @@ spec:
                         - value
                         type: object
                       type: array
+                    timeout:
+                      description: Timeout in seconds for the collector to execute
+                      type: integer
                     type:
                       description: Type is the type of collector to be used
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$


### PR DESCRIPTION
[RELEASE-910](https://issues.redhat.com//browse/RELEASE-910) talks about passing a timeout with the collector, but no timeout field was included when they were added with RELEASE-908. This commit adds the timeout field.