### PR TITLE
chore(RELEASE-903): remove advisoryRepo from RSC

### DIFF
--- a/api/v1alpha1/releaseserviceconfig_types.go
+++ b/api/v1alpha1/releaseserviceconfig_types.go
@@ -30,10 +30,6 @@ type ReleaseServiceConfigSpec struct {
 	// +optional
 	Debug bool `json:"debug,omitempty"`
 
-	// AdvisoryRepo is the repo to create advisories in during the managed release PipelineRun
-	// +optional
-	AdvisoryRepo string `json:"advisoryRepo,omitempty"`
-
 	// DefaultTimeouts contain the default Tekton timeouts to be used in case they are
 	// not specified in the ReleasePlanAdmission resource.
 	DefaultTimeouts tektonv1.TimeoutFields `json:"defaultTimeouts,omitempty"`

--- a/config/crd/bases/appstudio.redhat.com_releaseserviceconfigs.yaml
+++ b/config/crd/bases/appstudio.redhat.com_releaseserviceconfigs.yaml
@@ -42,10 +42,6 @@ spec:
           spec:
             description: ReleaseServiceConfigSpec defines the desired state of ReleaseServiceConfig.
             properties:
-              advisoryRepo:
-                description: AdvisoryRepo is the repo to create advisories in during
-                  the managed release PipelineRun
-                type: string
               debug:
                 description: |-
                   Debug is the boolean that specifies whether or not the Release Service should run


### PR DESCRIPTION
Remove AdvisoryRepo from ReleaseServiceConfig Spec as it is no longer used.