### PR TITLE
feat(RELEASE-1146): update release-service to go version 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21.11-9 as builder
+FROM golang:1.22 as builder
+
+WORKDIR /opt/app-root/src
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konflux-ci/release-service
 
-go 1.21
+go 1.22
 
 require (
 	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.50
@@ -20,6 +20,7 @@ require (
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.2 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/cel-go v0.20.0 // indirect
@@ -45,7 +46,6 @@ require (
 	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect


### PR DESCRIPTION
This commit updates the go builder image to version 1.22. In addition the WORKDIR /build is added due to the new version complaining as it uses a different build root in the new image.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>