### PR TITLE
fix(RELEASE-1150) add checks to fieldselectors

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -160,6 +160,11 @@ func (l *loader) GetMatchingReleasePlanAdmission(ctx context.Context, cli client
 // are in the namespace specified by the ReleasePlanAdmission's origin. If the List operation fails, an
 // error will be returned.
 func (l *loader) GetMatchingReleasePlans(ctx context.Context, cli client.Client, releasePlanAdmission *v1alpha1.ReleasePlanAdmission) (*v1alpha1.ReleasePlanList, error) {
+
+	if releasePlanAdmission.Spec.Origin == "" {
+		return nil, fmt.Errorf("releasePlanAdmission has no origin, so no ReleasePlans can be found")
+	}
+
 	releasePlans := &v1alpha1.ReleasePlanList{}
 	err := cli.List(ctx, releasePlans,
 		client.InNamespace(releasePlanAdmission.Spec.Origin),

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -250,6 +250,16 @@ var _ = Describe("Release Adapter", Ordered, func() {
 				return returnedObject != &v1alpha1.ReleasePlanList{} && err == nil && contains == false
 			})
 		})
+
+		It("fails to return release plans if origin is empty", func() {
+			modifiedReleasePlanAdmission := releasePlanAdmission.DeepCopy()
+			modifiedReleasePlanAdmission.Spec.Origin = ""
+
+			returnedObject, err := loader.GetMatchingReleasePlans(ctx, k8sClient, modifiedReleasePlanAdmission)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("releasePlanAdmission has no origin, so no ReleasePlans can be found"))
+			Expect(returnedObject).To(BeNil())
+		})
 	})
 
 	When("calling GetPreviousRelease", func() {


### PR DESCRIPTION
This commit fixes the issue of FieldSelectors retrurning everything when the argument is nill, added checks to each function using field selector.