### PR TITLE
fix: gitlint installation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -110,7 +110,7 @@ jobs:
         run: docker build -f ./Dockerfile .
   gitlint:
     name: Run gitlint checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -118,6 +118,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Install gitlint into container
-        run: python -m pip install gitlint
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          python3 -m pip install gitlint
       - name: Run gitlint check
-        run: gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD
+        run: |
+          source venv/bin/activate
+          gitlint --commits origin/${{ github.event.pull_request.base.ref }}..HEAD


### PR DESCRIPTION
Latest ubuntu does not allow system wide pip install. It can be overriden with `--break-system-packages`, but it's better to create a virtual env.

This first came up here: https://github.com/hacbs-release/app-interface-deployments/pull/198