### PR TITLE
fix(KFLUXBUGS-1754): rp shouldn't show matched if RPA doesn't exist

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -117,7 +117,11 @@ func (l *loader) GetMatchingReleasePlanAdmission(ctx context.Context, cli client
 
 	if designatedReleasePlanAdmissionName != "" {
 		releasePlanAdmission := &v1alpha1.ReleasePlanAdmission{}
-		return releasePlanAdmission, toolkit.GetObject(designatedReleasePlanAdmissionName, releasePlan.Spec.Target, cli, ctx, releasePlanAdmission)
+		err := toolkit.GetObject(designatedReleasePlanAdmissionName, releasePlan.Spec.Target, cli, ctx, releasePlanAdmission)
+		if err != nil {
+			return nil, err
+		}
+		return releasePlanAdmission, nil
 	}
 
 	if releasePlan.Spec.Target == "" {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			returnedObject, err := loader.GetMatchingReleasePlanAdmission(ctx, k8sClient, modifiedReleasePlan)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsNotFound(err)).To(BeTrue())
-			Expect(returnedObject).To(Equal(&v1alpha1.ReleasePlanAdmission{}))
+			Expect(returnedObject).To(BeNil())
 		})
 
 		It("fails to return a release plan admission if the target does not match", func() {


### PR DESCRIPTION
This commit fixes the loader function to return nil instead of an empty RPA if the RPA specified in the RP label does not exist.