### PR TITLE
fix: metrics fields in wrong order

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -455,11 +455,11 @@ func (r *Release) MarkReleased() {
 	go metrics.RegisterCompletedRelease(
 		r.Status.StartTime,
 		r.Status.CompletionTime,
+		r.getPhaseReason(tenantProcessedConditionType),
 		r.getPhaseReason(managedProcessedConditionType),
+		r.getPhaseReason(finalProcessedConditionType),
 		SucceededReason.String(),
 		r.Status.Target,
-		r.getPhaseReason(tenantProcessedConditionType),
-		r.getPhaseReason(finalProcessedConditionType),
 		r.getPhaseReason(validatedConditionType),
 	)
 }

--- a/metrics/release.go
+++ b/metrics/release.go
@@ -132,11 +132,11 @@ func RegisterCompletedRelease(startTime, completionTime *metav1.Time,
 
 	// Prometheus fails if these are not in alphabetical order
 	labels := prometheus.Labels{
-		"final_pipeline_processing_reason":   finalProcessingReason,
+		"tenant_pipeline_processing_reason":  tenantProcessingReason,
 		"managed_pipeline_processing_reason": managedProcessingReason,
+		"final_pipeline_processing_reason":   finalProcessingReason,
 		"release_reason":                     releaseReason,
 		"target":                             target,
-		"tenant_pipeline_processing_reason":  tenantProcessingReason,
 		"validation_reason":                  validationReason,
 	}
 	ReleaseConcurrentTotal.WithLabelValues().Dec()


### PR DESCRIPTION
this commit fixes the order which the metrics
parameters are sent, causing wrong data being
sent

Signed-off-by: Leandro Mendes <lmendes@redhat.com>