### PR TITLE
feat(RELEASE-1307): increases lease timeout

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,12 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --lease-duration
+        - 60
+        - --leader-renew-deadline
+        - 30
+        - --leader-elector-retry-period
+        - 10
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION
    this PR proposes a change in the default leader election
    time controls to decrease the etcd load and allowing the
    to wait time to renew the leadership, and also decreasing
    the number of requests to etcd.
    
    Signed-off-by: Leandro Mendes <lmendes@redhat.com>
