### PR TITLE
fix(KFLUXBUGS-1921): auto-release false RPA should end reconcile

### DIFF
--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -1001,7 +1001,7 @@ func (a *adapter) validatePipelineDefined() *controller.ValidationResult {
 		}
 		releasePlanAdmission, err := a.loader.GetActiveReleasePlanAdmissionFromRelease(a.ctx, a.client, a.release)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if errors.IsNotFound(err) || strings.Contains(err.Error(), "with auto-release label set to false") {
 				a.release.MarkValidationFailed(err.Error())
 				return &controller.ValidationResult{Valid: false}
 			}


### PR DESCRIPTION
If a ReleasePlanAdmission is found with auto-release set to false, it will continually requeue the error because it is not a not found error. Instead, the Release should be marked as validation false and reconciliation should end.