### PR TITLE
feat(RELEASE-1227): set application metadata in release controller

### DIFF
--- a/controllers/release/controller.go
+++ b/controllers/release/controller.go
@@ -79,6 +79,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		adapter.EnsureConfigIsLoaded, // This operation sets the config in the adapter to be used in other operations.
 		adapter.EnsureReleaseIsRunning,
 		adapter.EnsureReleaseIsValid,
+		adapter.EnsureApplicationMetadataIsSet,
 		adapter.EnsureFinalizerIsAdded,
 		adapter.EnsureReleaseExpirationTimeIsAdded,
 		adapter.EnsureTenantPipelineIsProcessed,

--- a/metadata/labels.go
+++ b/metadata/labels.go
@@ -21,43 +21,49 @@ import "fmt"
 // Common constants
 const (
 	// rhtapDomain is the prefix of the application label
-	rhtapDomain = "appstudio.openshift.io"
+	RhtapDomain = "appstudio.openshift.io"
 
 	// MaxLabelLength is the maximum allowed characters in a label value
 	MaxLabelLength = 63
 )
 
+// Prefixes used by the release controller package
+var (
+	// PipelinesAsCodePrefix contains the prefix applied to labels and annotations copied from Pipelines as Code resources.
+	PipelinesAsCodePrefix = "pac.test.appstudio.openshift.io"
+)
+
 // Labels used by the release api package
 var (
 	// AttributionLabel is the label name for the standing-attribution label
-	AttributionLabel = fmt.Sprintf("release.%s/standing-attribution", rhtapDomain)
+	AttributionLabel = fmt.Sprintf("release.%s/standing-attribution", RhtapDomain)
 
 	// AutoReleaseLabel is the label name for the auto-release setting
-	AutoReleaseLabel = fmt.Sprintf("release.%s/auto-release", rhtapDomain)
+	AutoReleaseLabel = fmt.Sprintf("release.%s/auto-release", RhtapDomain)
 
 	// AuthorLabel is the label name for the user who creates a CR
-	AuthorLabel = fmt.Sprintf("release.%s/author", rhtapDomain)
+	AuthorLabel = fmt.Sprintf("release.%s/author", RhtapDomain)
 
 	// AutomatedLabel is the label name for marking a Release as automated
-	AutomatedLabel = fmt.Sprintf("release.%s/automated", rhtapDomain)
+	AutomatedLabel = fmt.Sprintf("release.%s/automated", RhtapDomain)
 
 	// ReleasePlanAdmissionLabel is the ReleasePlan label for the name of the ReleasePlanAdmission to use
-	ReleasePlanAdmissionLabel = fmt.Sprintf("release.%s/releasePlanAdmission", rhtapDomain)
+	ReleasePlanAdmissionLabel = fmt.Sprintf("release.%s/releasePlanAdmission", RhtapDomain)
 )
 
 // Prefixes to be used by Release Pipelines labels
 var (
 	// pipelinesLabelPrefix is the prefix of the pipelines label
-	pipelinesLabelPrefix = fmt.Sprintf("pipelines.%s", rhtapDomain)
+	pipelinesLabelPrefix = fmt.Sprintf("pipelines.%s", RhtapDomain)
 
 	// releaseLabelPrefix is the prefix of the release labels
-	releaseLabelPrefix = fmt.Sprintf("release.%s", rhtapDomain)
+	releaseLabelPrefix = fmt.Sprintf("release.%s", RhtapDomain)
 )
 
 // Labels to be used within Release PipelineRuns
 var (
 	// ApplicationNameLabel is the label used to specify the application associated with the PipelineRun
-	ApplicationNameLabel = fmt.Sprintf("%s/%s", rhtapDomain, "application")
+	ApplicationNameLabel = fmt.Sprintf("%s/%s", RhtapDomain, "application")
 
 	// FinalPipelineType is the value to be used in the PipelinesTypeLabel for final Pipelines
 	FinalPipelineType = "final"
@@ -78,5 +84,5 @@ var (
 	ReleaseNamespaceLabel = fmt.Sprintf("%s/%s", releaseLabelPrefix, "namespace")
 
 	// ReleaseSnapshotLabel is the label used to specify the snapshot associated with the PipelineRun
-	ReleaseSnapshotLabel = fmt.Sprintf("%s/%s", rhtapDomain, "snapshot")
+	ReleaseSnapshotLabel = fmt.Sprintf("%s/%s", RhtapDomain, "snapshot")
 )


### PR DESCRIPTION
This commit adds an operation to the release controller to set metadata from the application on the release. It sets the ownerReference to be the application as well as copies the pipelines as code and rhtapDomain labels and annotations from the snapshot to the release. This is currently done for automated releases by the integration service, so this commit moves the logic to the release controller instead.