### PR TITLE
fix(RELEASE-1441): remove rsc from being managed

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,7 +1,6 @@
 resources:
 - manager.yaml
 - network_policy.yaml
-- release_service_config.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/release_service_config.yaml
+++ b/config/manager/release_service_config.yaml
@@ -1,6 +1,0 @@
-apiVersion: appstudio.redhat.com/v1alpha1
-kind: ReleaseServiceConfig
-metadata:
-  name: config
-spec:
-  debug: false


### PR DESCRIPTION
- the rsc needs to managed outside of the release service so that clusters can have a specific version for testing.
- A version can be deployed and managed by ArgoCD via infra-deployments for a specific cluster