### PR TITLE
chore(RELEASE-1444): upgrade GitHub workflows to Ubuntu-latest

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   report-coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -12,7 +12,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   gosec:
     name: Check GO security
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   go:
     name: Check sources
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       OPERATOR_SDK_VERSION: v1.18.0
     steps:
@@ -100,7 +100,7 @@ jobs:
         run: make bundle
   docker:
     name: Check docker build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4


### PR DESCRIPTION
Migrate GitHub workflows from Ubuntu 20.04 Ubuntu-latest