### PR TITLE
fix(RELEASE-1473): use rpa url for git resolver

### DIFF
--- a/api/v1alpha1/collectors.go
+++ b/api/v1alpha1/collectors.go
@@ -1,5 +1,11 @@
 package v1alpha1
 
+const (
+	DefaultReleaseCatalogUrl      = "https://github.com/konflux-ci/release-service-catalog.git"
+	DefaultReleaseCatalogRevision = "production"
+	DefaultCollectorPipelinePath  = "pipelines/run-collectors/run-collectors.yaml"
+)
+
 // Collectors holds the list of collectors to be executed as part of the release workflow along with the
 // ServiceAccount to be used in the PipelineRun.
 // +kubebuilder:object:generate=true

--- a/tekton/utils/pipeline.go
+++ b/tekton/utils/pipeline.go
@@ -104,6 +104,17 @@ func (pr *PipelineRef) GetRevision() (string, error) {
 	return "", fmt.Errorf("no revision found")
 }
 
+// GetUrl returns the value of the url param. If not found an error will be raised.
+func (pr *PipelineRef) GetUrl() (string, error) {
+	for _, param := range pr.Params {
+		if param.Name == "url" {
+			return param.Value, nil
+		}
+	}
+
+	return "", fmt.Errorf("no url found")
+}
+
 // ToTektonPipelineRef converts a PipelineRef object to Tekton's own PipelineRef type and returns it.
 func (pr *PipelineRef) ToTektonPipelineRef() *tektonv1.PipelineRef {
 	params := tektonv1.Params{}

--- a/tekton/utils/pipeline_test.go
+++ b/tekton/utils/pipeline_test.go
@@ -75,6 +75,20 @@ var _ = Describe("Pipeline", func() {
 		})
 	})
 
+	When("GetUrl method is called", func() {
+		It("should return the url if it exists", func() {
+			url, err := gitRef.GetUrl()
+			Expect(url).To(Equal("my-git-url"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not return the url if it does not exist", func() {
+			url, err := bundleRef.GetUrl()
+			Expect(url).To(BeEmpty())
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	When("GetRevision method is called", func() {
 		It("should return the revision if it exists", func() {
 			revision, err := gitRef.GetRevision()


### PR DESCRIPTION
- The git resolver url value passed from the controller to the
  run-collectors pipeline should be inherited from the RPA.
- introduce constants for default catalog url, revision and
  pathInRepo values for collectors.
