### PR TITLE
fix: change port to 8080 and endpoint to insecure

### DIFF
--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,4 +1,4 @@
 # This patch adds the args to allow exposing the metrics endpoint using HTTPS
 - op: add
   path: /spec/template/spec/containers/0/args/0
-  value: --metrics-bind-address=:8443
+  value: --metrics-bind-address=:8080

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -9,9 +9,9 @@ metadata:
   namespace: system
 spec:
   ports:
-  - name: https
-    port: 8443
+  - name: http
+    port: 8080
     protocol: TCP
-    targetPort: 8443
+    targetPort: 8080
   selector:
     control-plane: controller-manager

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -16,13 +16,11 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https
-      scheme: https
+      port: http
+      scheme: http
       bearerTokenSecret:
         key: token
         name: "release-service-metrics-reader"
-      tlsConfig:
-        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager


### PR DESCRIPTION
this PR changes the metrics port to 8080 as the service
in this port is not secured in the pod side

Signed-off-by: Leandro Mendes <lmendes@redhat.com>