### PR TITLE
fix: update task ref for build-sealights-container

### DIFF
--- a/.tekton/release-service-push.yaml
+++ b/.tekton/release-service-push.yaml
@@ -205,7 +205,7 @@ spec:
       workspaces:
       - name: git-basic-auth
         workspace: git-auth
-      - name: netrc 
+      - name: netrc
         workspace: netrc
     - name: build-container
       params:
@@ -231,7 +231,7 @@ spec:
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)  
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
       - prefetch-dependencies
       taskRef:
@@ -281,7 +281,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:63e57ac67f892a0e2990fc18db5c18ef5ad9de1db8df82c25d5813e2f84f5977
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:8abdd666a032d7088f31d0dbaa2a8ea07b85d814d08d157bb3ffa344dca5485a
         - name: kind
           value: task
         resolver: bundles
@@ -318,7 +318,7 @@ spec:
       - input: $(tasks.init.results.build)
         operator: in
         values:
-        - "true"  
+        - "true"
     - name: build-source-image
       params:
       - name: BINARY_IMAGE


### PR DESCRIPTION
- use latest trusted sha for the buildah-oci-ta task