### PR TITLE
feat: remove Release e2e pipelines events in favor of integration service contexts

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -97,6 +97,9 @@ spec:
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
           values: ["red-hat-konflux[bot]"]
+        - input: "$(tasks.test-metadata.results.component-name)"
+          operator: in
+          values: ["release-service"]
       runAfter:
         - rosa-hcp-metadata
         - test-metadata
@@ -131,6 +134,9 @@ spec:
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
           values: ["red-hat-konflux[bot]"]
+        - input: "$(tasks.test-metadata.results.component-name)"
+          operator: in
+          values: ["release-service"]
       runAfter:
         - provision-rosa
       taskRef:
@@ -171,6 +177,9 @@ spec:
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
           values: ["red-hat-konflux[bot]"]
+        - input: "$(tasks.test-metadata.results.component-name)"
+          operator: in
+          values: ["release-service"]
       taskRef:
         resolver: git
         params:
@@ -210,6 +219,9 @@ spec:
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
           values: ["red-hat-konflux[bot]"]
+        - input: "$(tasks.test-metadata.results.component-name)"
+          operator: in
+          values: ["release-service"]
       taskRef:
         resolver: git
         params:
@@ -235,6 +247,9 @@ spec:
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
           values: ["red-hat-konflux[bot]"]
+        - input: "$(tasks.test-metadata.results.component-name)"
+          operator: in
+          values: ["release-service"]
       taskRef:
         resolver: git
         params:

--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -94,9 +94,6 @@ spec:
           value: $(context.pipelineRun.name)
     - name: provision-rosa
       when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
           values: ["red-hat-konflux[bot]"]
@@ -131,9 +128,6 @@ spec:
     - name: konflux-e2e-tests
       timeout: 3h
       when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
           values: ["red-hat-konflux[bot]"]
@@ -174,9 +168,6 @@ spec:
   finally:
     - name: deprovision-rosa-collect-artifacts
       when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
           values: ["red-hat-konflux[bot]"]
@@ -216,9 +207,6 @@ spec:
           value: "$(tasks.status)"
     - name: quality-dashboard-upload
       when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
           values: ["red-hat-konflux[bot]"]
@@ -244,9 +232,6 @@ spec:
           value: "$(tasks.test-metadata.results.test-event-type)"
     - name: pull-request-status-message
       when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
           values: ["red-hat-konflux[bot]"]


### PR DESCRIPTION
Check docs for more info: https://konflux.pages.redhat.com/docs/users/testing/integration/choosing-contexts.html