### PR TITLE
fix(RELEASE-1503): end reconcilation if application doesn't match

### DIFF
--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -1295,8 +1295,8 @@ func (a *adapter) registerFinalProcessingStatus(pipelineRun *tektonv1.PipelineRu
 	return a.client.Status().Patch(a.ctx, a.release, patch)
 }
 
-// validateApplication will ensure that the same Application is used in both, the Snapshot and the ReleasePlan. If the
-// resources reference different Applications, an error will be returned.
+// validateApplication will ensure that the same Application is used in both the Snapshot and the ReleasePlan. If the
+// resources reference different Applications, the Release will be marked as invalid.
 func (a *adapter) validateApplication() *controller.ValidationResult {
 	releasePlan, err := a.loader.GetReleasePlan(a.ctx, a.client, a.release)
 	if err != nil {
@@ -1317,7 +1317,8 @@ func (a *adapter) validateApplication() *controller.ValidationResult {
 	}
 
 	if releasePlan.Spec.Application != snapshot.Spec.Application {
-		return &controller.ValidationResult{Err: fmt.Errorf("different Application referenced in ReleasePlan and Snapshot")}
+		a.release.MarkValidationFailed("different Application referenced in ReleasePlan and Snapshot")
+		return &controller.ValidationResult{Valid: false}
 	}
 
 	return &controller.ValidationResult{Valid: true}

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -3355,6 +3355,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 		})
 
 		It("returns invalid and error if the Application doesn't match", func() {
+			var conditionMsg string
 			newReleasePlan := releasePlan.DeepCopy()
 			newReleasePlan.Spec.Application = "non-existent"
 			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
@@ -3366,8 +3367,13 @@ var _ = Describe("Release adapter", Ordered, func() {
 
 			result := adapter.validateApplication()
 			Expect(result.Valid).To(BeFalse())
-			Expect(result.Err).To(HaveOccurred())
-			Expect(result.Err.Error()).To(Equal("different Application referenced in ReleasePlan and Snapshot"))
+			Expect(result.Err).NotTo(HaveOccurred())
+			for i := range adapter.release.Status.Conditions {
+				if adapter.release.Status.Conditions[i].Type == "Validated" {
+					conditionMsg = adapter.release.Status.Conditions[i].Message
+				}
+			}
+			Expect(conditionMsg).To(Equal("different Application referenced in ReleasePlan and Snapshot"))
 		})
 
 		It("returns invalid if the ReleasePlan is not found", func() {


### PR DESCRIPTION
This commit fixes the validateApplication function in the release adapter to mark the release as invalid if the Application in the Snapshot and ReleasePlan do not match. Previously, it would be endlessly requeued with error.