### PR TITLE
feat: use aws kind cluster for testing

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -81,6 +81,7 @@ spec:
           value: $(context.pipelineRun.name)
     - name: provision-kind-cluster
       runAfter:
+        - sealights-refs
         - test-metadata
       when:
         - input: "$(tasks.test-metadata.results.pull-request-author)"
@@ -285,3 +286,31 @@ spec:
           value: cluster-provision.log
         - name: enable-test-results-analysis
           value: "true"
+    - name: quality-dashboard-upload
+      when:
+        - input: "$(tasks.test-metadata.results.pull-request-author)"
+          operator: notin
+          values: ["red-hat-konflux[bot]"]
+        - input: "$(tasks.test-metadata.results.component-name)"
+          operator: in
+          values: ["release-service"]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
+      params:
+        - name: test-name
+          value: "$(context.pipelineRun.name)"
+        - name: oci-container
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
+        - name: quality-dashboard-api
+          value: $(params.quality-dashboard-api)
+        - name: pipeline-aggregate-status
+          value: "$(tasks.status)"
+        - name: test-event-type
+          value: "$(tasks.test-metadata.results.test-event-type)"

--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   description: |-
     This pipeline automates the process of running end-to-end tests for Konflux
-    using a ROSA (Red Hat OpenShift Service on AWS) cluster. The pipeline provisions
-    the ROSA cluster, installs Konflux using the infra-deployments, runs the tests, collects artifacts,
-    and finally deprovisions the ROSA cluster.
+    using a Kind cluster running on AWS cluster. The pipeline provisions
+    the Kind cluster, installs Konflux using the konflux-ci repository scripts, runs the tests, collects artifacts,
+    and finally deprovisions the Kind cluster.
   params:
     - name: SNAPSHOT
       description: 'The JSON string representing the snapshot of the application under test.'
@@ -31,9 +31,6 @@ spec:
     - name: konflux-test-infra-secret
       description: The name of secret where testing infrastructures credentials are stored.
       type: string
-    - name: cloud-credential-key
-      type: string
-      description: The key secret from konflux-test-infra-secret where all AWS ROSA configurations are stored.
     - name: replicas
       description: 'The number of replicas for the cluster nodes.'
       type: string
@@ -67,16 +64,6 @@ spec:
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
-    - name: rosa-hcp-metadata
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/rosa/hosted-cp/rosa-hcp-metadata/rosa-hcp-metadata.yaml
     - name: test-metadata
       taskRef:
         resolver: git
@@ -92,7 +79,9 @@ spec:
           value: $(params.SNAPSHOT)
         - name: test-name
           value: $(context.pipelineRun.name)
-    - name: provision-rosa
+    - name: provision-kind-cluster
+      runAfter:
+        - test-metadata
       when:
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
@@ -100,10 +89,6 @@ spec:
         - input: "$(tasks.test-metadata.results.component-name)"
           operator: in
           values: ["release-service"]
-      runAfter:
-        - rosa-hcp-metadata
-        - test-metadata
-        - sealights-refs
       taskRef:
         resolver: git
         params:
@@ -112,22 +97,52 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: tasks/rosa/hosted-cp/rosa-hcp-provision/0.2/rosa-hcp-provision.yaml
+            value: tasks/mapt-oci/kind-aws-spot/provision/0.1/kind-aws-provision.yaml
       params:
-        - name: cluster-name
-          value: "$(tasks.rosa-hcp-metadata.results.cluster-name)"
-        - name: ocp-version
-          value: "$(params.ocp-version)"
-        - name: replicas
-          value: "$(params.replicas)"
-        - name: machine-type
-          value: "$(params.machine-type)"
-        - name: konflux-test-infra-secret
-          value: "$(params.konflux-test-infra-secret)"
-        - name: cloud-credential-key
-          value: "$(params.cloud-credential-key)"
-        - name: oci-container
-          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
+        - name: secret-aws-credentials
+          value: mapt-kind-secret
+        - name: id
+          value: $(context.pipelineRun.name)
+        - name: tags
+          value: env=konflux,user=release-service
+        - name: debug
+          value: 'false'
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: deploy-konflux
+      when:
+        - input: "$(tasks.test-metadata.results.pull-request-author)"
+          operator: notin
+          values: ["red-hat-konflux[bot]"]
+        - input: "$(tasks.test-metadata.results.component-name)"
+          operator: in
+          values: ["release-service"]
+      runAfter:
+        - provision-kind-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/konflux-ci/deploy/0.1/deploy-konflux-ci.yaml
+      params:
+        - name: cluster-access-secret
+          value: $(tasks.provision-kind-cluster.results.cluster-access-secret)
+        - name: component-name
+          value: release-service
+        - name: component-pr-owner
+          value: $(tasks.test-metadata.results.pull-request-author)
+        - name: component-pr-sha
+          value: $(tasks.test-metadata.results.git-revision)
+        - name: component-pr-source-branch
+          value: $(tasks.test-metadata.results.source-repo-branch)
     - name: konflux-e2e-tests
       timeout: 3h
       when:
@@ -138,7 +153,7 @@ spec:
           operator: in
           values: ["release-service"]
       runAfter:
-        - provision-rosa
+        - deploy-konflux
       taskRef:
         resolver: git
         params:
@@ -147,7 +162,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: integration-tests/tasks/konflux-e2e-tests-task.yaml
+            value: integration-tests/tasks/konflux-e2e-tests/0.2/konflux-e2e-tests.yaml
       params:
         - name: test-name
           value: "$(context.pipelineRun.name)"
@@ -161,8 +176,6 @@ spec:
           value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
         - name: job-spec
           value: "$(tasks.test-metadata.results.job-spec)"
-        - name: ocp-login-command
-          value: "$(tasks.provision-rosa.results.ocp-login-command)"
         - name: component-image
           value: $(tasks.sealights-refs.results.sealights-container-image)
         - name: sealights-bsid
@@ -171,6 +184,10 @@ spec:
           value: $(params.test-stage)
         - name: enable-sealights
           value: $(params.enable-sealights)
+        - name: cluster-access-secret-name
+          value: $(tasks.provision-kind-cluster.results.cluster-access-secret)
+        - name: test-environment
+          value: "upstream"
   finally:
     - name: store-pipeline-status
       when:
@@ -198,7 +215,7 @@ spec:
           value: $(context.pipelineRun.name)
         - name: pipeline-aggregate-status
           value: $(tasks.status)
-    - name: deprovision-rosa-collect-artifacts
+    - name: deprovision-kind-cluster
       when:
         - input: "$(tasks.test-metadata.results.pull-request-author)"
           operator: notin
@@ -214,60 +231,18 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.2/rosa-hcp-deprovision.yaml
+            value: tasks/mapt-oci/kind-aws-spot/deprovision/0.1/kind-aws-deprovision.yaml
       params:
-        - name: test-name
-          value: "$(context.pipelineRun.name)"
-        - name: ocp-login-command
-          value: "$(tasks.provision-rosa.results.ocp-login-command)"
+        - name: secret-aws-credentials
+          value: mapt-kind-secret
+        - name: id
+          value: $(context.pipelineRun.name)
+        - name: cluster-access-secret
+          value: $(tasks.provision-kind-cluster.results.cluster-access-secret)
         - name: oci-container
-          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
-        - name: pull-request-author
-          value: "$(tasks.test-metadata.results.pull-request-author)"
-        - name: git-revision
-          value: "$(tasks.test-metadata.results.git-revision)"
-        - name: pull-request-number
-          value: "$(tasks.test-metadata.results.pull-request-number)"
-        - name: git-repo
-          value: "$(tasks.test-metadata.results.git-repo)"
-        - name: git-org
-          value: "$(tasks.test-metadata.results.git-org)"
-        - name: cluster-name
-          value: "$(tasks.rosa-hcp-metadata.results.cluster-name)"
-        - name: konflux-test-infra-secret
-          value: "$(params.konflux-test-infra-secret)"
-        - name: cloud-credential-key
-          value: "$(params.cloud-credential-key)"
-        - name: pipeline-aggregate-status
-          value: "$(tasks.status)"
-    - name: quality-dashboard-upload
-      when:
-        - input: "$(tasks.test-metadata.results.pull-request-author)"
-          operator: notin
-          values: ["red-hat-konflux[bot]"]
-        - input: "$(tasks.test-metadata.results.component-name)"
-          operator: in
-          values: ["release-service"]
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
-      params:
-        - name: test-name
-          value: "$(context.pipelineRun.name)"
-        - name: oci-container
-          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
-        - name: quality-dashboard-api
-          value: $(params.quality-dashboard-api)
-        - name: pipeline-aggregate-status
-          value: "$(tasks.status)"
-        - name: test-event-type
-          value: "$(tasks.test-metadata.results.test-event-type)"
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
+        - name: oci-credentials
+          value: konflux-test-infra
     - name: pull-request-status-message
       when:
         - input: "$(tasks.test-metadata.results.pull-request-author)"


### PR DESCRIPTION
* use [kind cluster](https://github.com/konflux-ci/tekton-integration-catalog/tree/main/tasks/mapt-oci/kind-aws-spot) as a testing infra
* [deploy using konflux-ci scripts](https://github.com/konflux-ci/tekton-integration-catalog/tree/main/tasks/konflux-ci/deploy/0.1) instead of infra-deployments
* [skip bootstrapping a cluster in e2e-tests repo](https://github.com/konflux-ci/e2e-tests/pull/1606)

## Relevant Jira
https://issues.redhat.com/browse/KFLUXDP-290