### PR TITLE
feat(KFLUXDP-239): remove quality dashboard task

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -40,9 +40,6 @@ spec:
     - name: oci-container-repo
       default: 'quay.io/konflux-test-storage/konflux-team/release-service'
       description: The ORAS container used to store all test artifacts.
-    - name: quality-dashboard-api
-      default: 'none'
-      description: 'Contains the url of the backend to send metrics for quality purposes.'
     - name: component-image
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
@@ -296,31 +293,3 @@ spec:
           value: cluster-provision.log
         - name: enable-test-results-analysis
           value: "true"
-    - name: quality-dashboard-upload
-      when:
-        - input: "$(tasks.test-metadata.results.pull-request-author)"
-          operator: notin
-          values: ["red-hat-konflux[bot]"]
-        - input: "$(tasks.test-metadata.results.component-name)"
-          operator: in
-          values: ["release-service"]
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
-      params:
-        - name: test-name
-          value: "$(context.pipelineRun.name)"
-        - name: oci-container
-          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
-        - name: quality-dashboard-api
-          value: $(params.quality-dashboard-api)
-        - name: pipeline-aggregate-status
-          value: "$(tasks.status)"
-        - name: test-event-type
-          value: "$(tasks.test-metadata.results.test-event-type)"


### PR DESCRIPTION
We dont need anymore to push artifacts to quality dashboard. The dashboard is able to pull the artifacts automatically after implementing https://issues.redhat.com/browse/KFLUXDP-240