### PR TITLE
fix: release service image tag in push events

### DIFF
--- a/.tekton/release-service-push.yaml
+++ b/.tekton/release-service-push.yaml
@@ -21,7 +21,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service/release-service:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service/release-service:{{revision}}
   - name: path-context
     value: .
   - name: revision


### PR DESCRIPTION
The image tags are currently in the "on-pr-<commit-sha>" format for
 both push and pull request events.
This PR changes the tag format for push events to distinguish them
 from those for pull request events.