### PR TITLE
refactor(RELEASE-1352): add block-releases label to RPAs

### DIFF
--- a/api/v1alpha1/releaseplan_types.go
+++ b/api/v1alpha1/releaseplan_types.go
@@ -124,7 +124,11 @@ func (rp *ReleasePlan) setMatchedStatus(releasePlanAdmission *ReleasePlanAdmissi
 	if releasePlanAdmission != nil {
 		rp.Status.ReleasePlanAdmission.Name = fmt.Sprintf("%s%c%s", releasePlanAdmission.GetNamespace(),
 			types.Separator, releasePlanAdmission.GetName())
-		rp.Status.ReleasePlanAdmission.Active = (releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel] == "true")
+		active := (releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel] == "true")
+		if _, found := releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel]; found {
+			active = (releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel] == "false")
+		}
+		rp.Status.ReleasePlanAdmission.Active = active
 	}
 
 	conditions.SetCondition(&rp.Status.Conditions, MatchedConditionType, status, MatchedReason)

--- a/api/v1alpha1/releaseplan_types_test.go
+++ b/api/v1alpha1/releaseplan_types_test.go
@@ -125,5 +125,16 @@ var _ = Describe("ReleasePlan type", func() {
 			Expect(condition).NotTo(BeNil())
 			Expect(condition.Status).To(Equal(metav1.ConditionUnknown))
 		})
+
+		It("should set the ReleasePlanAdmission and matched condition using the block-releases label", func() {
+			releasePlanAdmission.Labels[metadata.BlockReleasesLabel] = "false"
+			releasePlanAdmission.Labels[metadata.AutoReleaseLabel] = "false"
+			releasePlan.setMatchedStatus(releasePlanAdmission, metav1.ConditionUnknown)
+			Expect(releasePlan.Status.ReleasePlanAdmission.Name).To(Equal("default/rpa"))
+			Expect(releasePlan.Status.ReleasePlanAdmission.Active).To(BeTrue())
+			condition := meta.FindStatusCondition(releasePlan.Status.Conditions, MatchedConditionType.String())
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionUnknown))
+		})
 	})
 })

--- a/api/v1alpha1/releaseplanadmission_types_test.go
+++ b/api/v1alpha1/releaseplanadmission_types_test.go
@@ -36,7 +36,8 @@ var _ = Describe("ReleasePlanAdmission type", func() {
 					Name:      "rp",
 					Namespace: "default",
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel: "true",
+						metadata.AutoReleaseLabel:   "true",
+						metadata.BlockReleasesLabel: "false",
 					},
 				},
 			}
@@ -77,7 +78,8 @@ var _ = Describe("ReleasePlanAdmission type", func() {
 					Name:      "rp",
 					Namespace: "default",
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel: "true",
+						metadata.AutoReleaseLabel:   "true",
+						metadata.BlockReleasesLabel: "false",
 					},
 				},
 			}
@@ -112,7 +114,8 @@ var _ = Describe("ReleasePlanAdmission type", func() {
 					Name:      "r",
 					Namespace: "default",
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel: "true",
+						metadata.AutoReleaseLabel:   "true",
+						metadata.BlockReleasesLabel: "false",
 					},
 				},
 			}

--- a/api/v1alpha1/webhooks/releaseplanadmission/webhook_test.go
+++ b/api/v1alpha1/webhooks/releaseplanadmission/webhook_test.go
@@ -82,12 +82,37 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 		})
 	})
 
+	When("a ReleasePlanAdmission is created without the block-releases label", func() {
+		It("should get the label added with its value set to false", func() {
+			Expect(k8sClient.Create(ctx, releasePlanAdmission)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      releasePlanAdmission.Name,
+					Namespace: releasePlanAdmission.Namespace,
+				}, releasePlanAdmission)
+
+				labelValue, ok := releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel]
+
+				return err == nil && ok && labelValue == "false"
+			}, timeout).Should(BeTrue())
+		})
+	})
+
 	When("a ReleasePlanAdmission is created with an invalid auto-release label value", func() {
 		It("should get rejected until the value is valid", func() {
 			releasePlanAdmission.Labels = map[string]string{metadata.AutoReleaseLabel: "foo"}
 			err := k8sClient.Create(ctx, releasePlanAdmission)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", metadata.AutoReleaseLabel))
+		})
+	})
+
+	When("a ReleasePlanAdmission is created with an invalid block-releases label value", func() {
+		It("should get rejected until the value is valid", func() {
+			releasePlanAdmission.Labels = map[string]string{metadata.BlockReleasesLabel: "foo"}
+			err := k8sClient.Create(ctx, releasePlanAdmission)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", metadata.BlockReleasesLabel))
 		})
 	})
 
@@ -127,6 +152,42 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 		})
 	})
 
+	When("a ReleasePlanAdmission is created with a valid block-releases label value", func() {
+		It("shouldn't be modified", func() {
+			By("setting label to true")
+			localReleasePlanAdmission := releasePlanAdmission.DeepCopy()
+			localReleasePlanAdmission.Labels = map[string]string{metadata.BlockReleasesLabel: "true"}
+			Expect(k8sClient.Create(ctx, localReleasePlanAdmission)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      localReleasePlanAdmission.Name,
+					Namespace: localReleasePlanAdmission.Namespace,
+				}, localReleasePlanAdmission)
+
+				labelValue, ok := localReleasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel]
+
+				return err == nil && ok && labelValue == "true"
+			}, timeout).Should(BeTrue())
+
+			Expect(k8sClient.Delete(ctx, localReleasePlanAdmission)).To(Succeed())
+
+			By("setting label to false")
+			localReleasePlanAdmission = releasePlanAdmission.DeepCopy()
+			localReleasePlanAdmission.Labels = map[string]string{metadata.BlockReleasesLabel: "false"}
+			Expect(k8sClient.Create(ctx, localReleasePlanAdmission)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      localReleasePlanAdmission.Name,
+					Namespace: localReleasePlanAdmission.Namespace,
+				}, localReleasePlanAdmission)
+
+				labelValue, ok := localReleasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel]
+
+				return err == nil && ok && labelValue == "false"
+			}, timeout).Should(BeTrue())
+		})
+	})
+
 	When("a ReleasePlanAdmission is updated using an invalid auto-release label value", func() {
 		It("shouldn't be modified", func() {
 			Expect(k8sClient.Create(ctx, releasePlanAdmission)).Should(Succeed())
@@ -134,6 +195,16 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 			err := k8sClient.Update(ctx, releasePlanAdmission)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", metadata.AutoReleaseLabel))
+		})
+	})
+
+	When("a ReleasePlanAdmission is updated using an invalid block-releases label value", func() {
+		It("shouldn't be modified", func() {
+			Expect(k8sClient.Create(ctx, releasePlanAdmission)).Should(Succeed())
+			releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel] = "foo"
+			err := k8sClient.Update(ctx, releasePlanAdmission)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", metadata.BlockReleasesLabel))
 		})
 	})
 

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -4410,7 +4410,8 @@ var _ = Describe("Release adapter", Ordered, func() {
 							Name:      "release-plan-admission",
 							Namespace: "default",
 							Labels: map[string]string{
-								metadata.AutoReleaseLabel: "true",
+								metadata.AutoReleaseLabel:   "true",
+								metadata.BlockReleasesLabel: "false",
 							},
 						},
 						Spec: v1alpha1.ReleasePlanAdmissionSpec{
@@ -4448,7 +4449,8 @@ var _ = Describe("Release adapter", Ordered, func() {
 							Name:      "release-plan",
 							Namespace: "default",
 							Labels: map[string]string{
-								metadata.AutoReleaseLabel: "true",
+								metadata.AutoReleaseLabel:   "true",
+								metadata.BlockReleasesLabel: "false",
 							},
 						},
 						Spec: v1alpha1.ReleasePlanSpec{
@@ -4542,7 +4544,8 @@ var _ = Describe("Release adapter", Ordered, func() {
 							Name:      "release-plan-admission",
 							Namespace: "default",
 							Labels: map[string]string{
-								metadata.AutoReleaseLabel: "true",
+								metadata.AutoReleaseLabel:   "true",
+								metadata.BlockReleasesLabel: "false",
 							},
 						},
 						Spec: v1alpha1.ReleasePlanAdmissionSpec{
@@ -4642,7 +4645,8 @@ var _ = Describe("Release adapter", Ordered, func() {
 							Name:      "release-plan-admission",
 							Namespace: "default",
 							Labels: map[string]string{
-								metadata.AutoReleaseLabel: "true",
+								metadata.AutoReleaseLabel:   "true",
+								metadata.BlockReleasesLabel: "false",
 							},
 						},
 						Spec: v1alpha1.ReleasePlanAdmissionSpec{
@@ -4736,7 +4740,8 @@ var _ = Describe("Release adapter", Ordered, func() {
 							Name:      "release-plan-admission",
 							Namespace: "default",
 							Labels: map[string]string{
-								metadata.AutoReleaseLabel: "true",
+								metadata.AutoReleaseLabel:   "true",
+								metadata.BlockReleasesLabel: "false",
 							},
 						},
 						Spec: v1alpha1.ReleasePlanAdmissionSpec{
@@ -4967,7 +4972,8 @@ var _ = Describe("Release adapter", Ordered, func() {
 				Name:      "release-plan-admission",
 				Namespace: "default",
 				Labels: map[string]string{
-					metadata.AutoReleaseLabel: "true",
+					metadata.AutoReleaseLabel:   "true",
+					metadata.BlockReleasesLabel: "false",
 				},
 			},
 			Spec: v1alpha1.ReleasePlanAdmissionSpec{

--- a/controllers/utils/predicates/predicates.go
+++ b/controllers/utils/predicates/predicates.go
@@ -44,7 +44,7 @@ func MatchPredicate() predicate.Predicate {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return haveApplicationsChanged(e.ObjectOld, e.ObjectNew) ||
-				hasAutoReleaseLabelChanged(e.ObjectOld, e.ObjectNew) ||
+				hasBehaviorLabelChanged(e.ObjectOld, e.ObjectNew) ||
 				hasMatchConditionChanged(e.ObjectOld, e.ObjectNew) ||
 				hasSourceChanged(e.ObjectOld, e.ObjectNew)
 		},
@@ -61,10 +61,16 @@ func hasConditionChanged(conditionOld, conditionNew *metav1.Condition) bool {
 	return !conditionOld.LastTransitionTime.Equal(&conditionNew.LastTransitionTime)
 }
 
-// hasAutoReleaseLabelChanged returns true if the auto-release label value is
+// hasBehaviorLabelChanged returns true if the auto-release or block-releases label value is
 // different between the two objects.
-func hasAutoReleaseLabelChanged(objectOld, objectNew client.Object) bool {
-	return objectOld.GetLabels()[metadata.AutoReleaseLabel] != objectNew.GetLabels()[metadata.AutoReleaseLabel]
+func hasBehaviorLabelChanged(objectOld, objectNew client.Object) bool {
+	if objectOld.GetLabels()[metadata.AutoReleaseLabel] != objectNew.GetLabels()[metadata.AutoReleaseLabel] {
+		return true
+	}
+	if objectOld.GetLabels()[metadata.BlockReleasesLabel] != objectNew.GetLabels()[metadata.BlockReleasesLabel] {
+		return true
+	}
+	return false
 }
 
 // haveApplicationsChanged returns true if passed objects are of the same kind and the

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -52,9 +52,9 @@ func NewLoader() ObjectLoader {
 }
 
 // GetActiveReleasePlanAdmission returns the ReleasePlanAdmission targeted by the given ReleasePlan.
-// Only ReleasePlanAdmissions with the 'auto-release' label set to true (or missing the label, which is
-// treated the same as having the label and it being set to true) will be searched for. If a matching
-// ReleasePlanAdmission is not found or the List operation fails, an error will be returned.
+// Only ReleasePlanAdmissions with the 'auto-release' label set to true and the 'block-releases' label
+// set to false will be searched for. If a matching ReleasePlanAdmission is not found or the List
+// operation fails, an error will be returned.
 func (l *loader) GetActiveReleasePlanAdmission(ctx context.Context, cli client.Client, releasePlan *v1alpha1.ReleasePlan) (*v1alpha1.ReleasePlanAdmission, error) {
 	releasePlanAdmission, err := l.GetMatchingReleasePlanAdmission(ctx, cli, releasePlan)
 	if err != nil {
@@ -64,6 +64,12 @@ func (l *loader) GetActiveReleasePlanAdmission(ctx context.Context, cli client.C
 	labelValue, found := releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel]
 	if found && labelValue == "false" {
 		return nil, fmt.Errorf("found ReleasePlanAdmission '%s' with auto-release label set to false",
+			releasePlanAdmission.Name)
+	}
+
+	labelValue, found = releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel]
+	if found && labelValue == "true" {
+		return nil, fmt.Errorf("found ReleasePlanAdmission '%s' with block-releases label set to true",
 			releasePlanAdmission.Name)
 	}
 

--- a/metadata/labels.go
+++ b/metadata/labels.go
@@ -50,6 +50,9 @@ var (
 	// AutomatedLabel is the label name for marking a Release as automated
 	AutomatedLabel = fmt.Sprintf("release.%s/automated", RhtapDomain)
 
+	// BlockReleasesLabel is the label name for the block-releases setting
+	BlockReleasesLabel = fmt.Sprintf("release.%s/block-releases", RhtapDomain)
+
 	// ServiceNameLabel is the label used to specify the service associated with an object
 	ServiceNameLabel = fmt.Sprintf("%s/%s", RhtapDomain, "service")
 


### PR DESCRIPTION
This commit is the first for [RELEASE-1352](https://issues.redhat.com//browse/RELEASE-1352). It adds the block-releases label for ReleasePlanAdmissions. This will take the place of the auto-release label, with the hope of increasing clarity. The auto-release label still exists with this commit, but once all ReleasePlanAdmissions are migrated, a future commit will remove it (just for RPAs, not for RPs).