### PR TITLE
chore(RELEASE-1352): cleanup old RPA auto-release code

### DIFF
--- a/api/v1alpha1/releaseplan_types.go
+++ b/api/v1alpha1/releaseplan_types.go
@@ -124,11 +124,7 @@ func (rp *ReleasePlan) setMatchedStatus(releasePlanAdmission *ReleasePlanAdmissi
 	if releasePlanAdmission != nil {
 		rp.Status.ReleasePlanAdmission.Name = fmt.Sprintf("%s%c%s", releasePlanAdmission.GetNamespace(),
 			types.Separator, releasePlanAdmission.GetName())
-		active := (releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel] == "true")
-		if _, found := releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel]; found {
-			active = (releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel] == "false")
-		}
-		rp.Status.ReleasePlanAdmission.Active = active
+		rp.Status.ReleasePlanAdmission.Active = (releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel] == "false")
 	}
 
 	conditions.SetCondition(&rp.Status.Conditions, MatchedConditionType, status, MatchedReason)

--- a/api/v1alpha1/releaseplan_types_test.go
+++ b/api/v1alpha1/releaseplan_types_test.go
@@ -111,24 +111,13 @@ var _ = Describe("ReleasePlan type", func() {
 					Name:      "rpa",
 					Namespace: "default",
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel: "true",
+						metadata.BlockReleasesLabel: "false",
 					},
 				},
 			}
 		})
 
 		It("should set the ReleasePlanAdmission and matched condition", func() {
-			releasePlan.setMatchedStatus(releasePlanAdmission, metav1.ConditionUnknown)
-			Expect(releasePlan.Status.ReleasePlanAdmission.Name).To(Equal("default/rpa"))
-			Expect(releasePlan.Status.ReleasePlanAdmission.Active).To(BeTrue())
-			condition := meta.FindStatusCondition(releasePlan.Status.Conditions, MatchedConditionType.String())
-			Expect(condition).NotTo(BeNil())
-			Expect(condition.Status).To(Equal(metav1.ConditionUnknown))
-		})
-
-		It("should set the ReleasePlanAdmission and matched condition using the block-releases label", func() {
-			releasePlanAdmission.Labels[metadata.BlockReleasesLabel] = "false"
-			releasePlanAdmission.Labels[metadata.AutoReleaseLabel] = "false"
 			releasePlan.setMatchedStatus(releasePlanAdmission, metav1.ConditionUnknown)
 			Expect(releasePlan.Status.ReleasePlanAdmission.Name).To(Equal("default/rpa"))
 			Expect(releasePlan.Status.ReleasePlanAdmission.Active).To(BeTrue())

--- a/api/v1alpha1/releaseplanadmission_types_test.go
+++ b/api/v1alpha1/releaseplanadmission_types_test.go
@@ -36,8 +36,7 @@ var _ = Describe("ReleasePlanAdmission type", func() {
 					Name:      "rp",
 					Namespace: "default",
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel:   "true",
-						metadata.BlockReleasesLabel: "false",
+						metadata.AutoReleaseLabel: "true",
 					},
 				},
 			}
@@ -78,8 +77,7 @@ var _ = Describe("ReleasePlanAdmission type", func() {
 					Name:      "rp",
 					Namespace: "default",
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel:   "true",
-						metadata.BlockReleasesLabel: "false",
+						metadata.AutoReleaseLabel: "true",
 					},
 				},
 			}
@@ -114,8 +112,7 @@ var _ = Describe("ReleasePlanAdmission type", func() {
 					Name:      "r",
 					Namespace: "default",
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel:   "true",
-						metadata.BlockReleasesLabel: "false",
+						metadata.AutoReleaseLabel: "true",
 					},
 				},
 			}

--- a/api/v1alpha1/webhooks/releaseplanadmission/webhook.go
+++ b/api/v1alpha1/webhooks/releaseplanadmission/webhook.go
@@ -39,16 +39,6 @@ type Webhook struct {
 func (w *Webhook) Default(ctx context.Context, obj runtime.Object) error {
 	releasePlanAdmission := obj.(*v1alpha1.ReleasePlanAdmission)
 
-	if _, found := releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel]; !found {
-		if releasePlanAdmission.Labels == nil {
-			releasePlanAdmission.Labels = map[string]string{
-				metadata.AutoReleaseLabel: "true",
-			}
-		} else {
-			releasePlanAdmission.Labels[metadata.AutoReleaseLabel] = "true"
-		}
-	}
-
 	if _, found := releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel]; !found {
 		if releasePlanAdmission.Labels == nil {
 			releasePlanAdmission.Labels = map[string]string{
@@ -93,15 +83,9 @@ func (w *Webhook) ValidateDelete(ctx context.Context, obj runtime.Object) (warni
 }
 
 // validateAutoReleaseLabel throws an error if the block-releases label value is set to anything besides true or false.
-// This function also temporarily supports the auto-release label.
 func (w *Webhook) validateBlockReleasesLabel(obj runtime.Object) (warnings admission.Warnings, err error) {
 	releasePlanAdmission := obj.(*v1alpha1.ReleasePlanAdmission)
 
-	if value, found := releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel]; found {
-		if value != "true" && value != "false" {
-			return nil, fmt.Errorf("'%s' label can only be set to true or false", metadata.AutoReleaseLabel)
-		}
-	}
 	if value, found := releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel]; found {
 		if value != "true" && value != "false" {
 			return nil, fmt.Errorf("'%s' label can only be set to true or false", metadata.BlockReleasesLabel)

--- a/api/v1alpha1/webhooks/releaseplanadmission/webhook_test.go
+++ b/api/v1alpha1/webhooks/releaseplanadmission/webhook_test.go
@@ -66,22 +66,6 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 	})
 
-	When("a ReleasePlanAdmission is created without the auto-release label", func() {
-		It("should get the label added with its value set to true", func() {
-			Expect(k8sClient.Create(ctx, releasePlanAdmission)).Should(Succeed())
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      releasePlanAdmission.Name,
-					Namespace: releasePlanAdmission.Namespace,
-				}, releasePlanAdmission)
-
-				labelValue, ok := releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel]
-
-				return err == nil && ok && labelValue == "true"
-			}, timeout).Should(BeTrue())
-		})
-	})
-
 	When("a ReleasePlanAdmission is created without the block-releases label", func() {
 		It("should get the label added with its value set to false", func() {
 			Expect(k8sClient.Create(ctx, releasePlanAdmission)).Should(Succeed())
@@ -98,57 +82,12 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 		})
 	})
 
-	When("a ReleasePlanAdmission is created with an invalid auto-release label value", func() {
-		It("should get rejected until the value is valid", func() {
-			releasePlanAdmission.Labels = map[string]string{metadata.AutoReleaseLabel: "foo"}
-			err := k8sClient.Create(ctx, releasePlanAdmission)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", metadata.AutoReleaseLabel))
-		})
-	})
-
 	When("a ReleasePlanAdmission is created with an invalid block-releases label value", func() {
 		It("should get rejected until the value is valid", func() {
 			releasePlanAdmission.Labels = map[string]string{metadata.BlockReleasesLabel: "foo"}
 			err := k8sClient.Create(ctx, releasePlanAdmission)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", metadata.BlockReleasesLabel))
-		})
-	})
-
-	When("a ReleasePlanAdmission is created with a valid auto-release label value", func() {
-		It("shouldn't be modified", func() {
-			By("setting label to true")
-			localReleasePlanAdmission := releasePlanAdmission.DeepCopy()
-			localReleasePlanAdmission.Labels = map[string]string{metadata.AutoReleaseLabel: "true"}
-			Expect(k8sClient.Create(ctx, localReleasePlanAdmission)).Should(Succeed())
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      localReleasePlanAdmission.Name,
-					Namespace: localReleasePlanAdmission.Namespace,
-				}, localReleasePlanAdmission)
-
-				labelValue, ok := localReleasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel]
-
-				return err == nil && ok && labelValue == "true"
-			}, timeout).Should(BeTrue())
-
-			Expect(k8sClient.Delete(ctx, localReleasePlanAdmission)).To(Succeed())
-
-			By("setting label to false")
-			localReleasePlanAdmission = releasePlanAdmission.DeepCopy()
-			localReleasePlanAdmission.Labels = map[string]string{metadata.AutoReleaseLabel: "false"}
-			Expect(k8sClient.Create(ctx, localReleasePlanAdmission)).Should(Succeed())
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      localReleasePlanAdmission.Name,
-					Namespace: localReleasePlanAdmission.Namespace,
-				}, localReleasePlanAdmission)
-
-				labelValue, ok := localReleasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel]
-
-				return err == nil && ok && labelValue == "false"
-			}, timeout).Should(BeTrue())
 		})
 	})
 
@@ -185,16 +124,6 @@ var _ = Describe("ReleasePlanAdmission webhook", func() {
 
 				return err == nil && ok && labelValue == "false"
 			}, timeout).Should(BeTrue())
-		})
-	})
-
-	When("a ReleasePlanAdmission is updated using an invalid auto-release label value", func() {
-		It("shouldn't be modified", func() {
-			Expect(k8sClient.Create(ctx, releasePlanAdmission)).Should(Succeed())
-			releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel] = "foo"
-			err := k8sClient.Update(ctx, releasePlanAdmission)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("'%s' label can only be set to true or false", metadata.AutoReleaseLabel))
 		})
 	})
 

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -4410,7 +4410,6 @@ var _ = Describe("Release adapter", Ordered, func() {
 							Name:      "release-plan-admission",
 							Namespace: "default",
 							Labels: map[string]string{
-								metadata.AutoReleaseLabel:   "true",
 								metadata.BlockReleasesLabel: "false",
 							},
 						},
@@ -4449,7 +4448,6 @@ var _ = Describe("Release adapter", Ordered, func() {
 							Name:      "release-plan",
 							Namespace: "default",
 							Labels: map[string]string{
-								metadata.AutoReleaseLabel:   "true",
 								metadata.BlockReleasesLabel: "false",
 							},
 						},
@@ -4544,7 +4542,6 @@ var _ = Describe("Release adapter", Ordered, func() {
 							Name:      "release-plan-admission",
 							Namespace: "default",
 							Labels: map[string]string{
-								metadata.AutoReleaseLabel:   "true",
 								metadata.BlockReleasesLabel: "false",
 							},
 						},
@@ -4645,7 +4642,6 @@ var _ = Describe("Release adapter", Ordered, func() {
 							Name:      "release-plan-admission",
 							Namespace: "default",
 							Labels: map[string]string{
-								metadata.AutoReleaseLabel:   "true",
 								metadata.BlockReleasesLabel: "false",
 							},
 						},
@@ -4740,7 +4736,6 @@ var _ = Describe("Release adapter", Ordered, func() {
 							Name:      "release-plan-admission",
 							Namespace: "default",
 							Labels: map[string]string{
-								metadata.AutoReleaseLabel:   "true",
 								metadata.BlockReleasesLabel: "false",
 							},
 						},
@@ -4972,7 +4967,6 @@ var _ = Describe("Release adapter", Ordered, func() {
 				Name:      "release-plan-admission",
 				Namespace: "default",
 				Labels: map[string]string{
-					metadata.AutoReleaseLabel:   "true",
 					metadata.BlockReleasesLabel: "false",
 				},
 			},

--- a/controllers/utils/predicates/predicates_test.go
+++ b/controllers/utils/predicates/predicates_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Predicates", Ordered, func() {
 					Name:      "releaseplanadmission-app",
 					Namespace: namespace,
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel: "true",
+						metadata.BlockReleasesLabel: "false",
 					},
 				},
 				Spec: v1alpha1.ReleasePlanAdmissionSpec{
@@ -198,7 +198,7 @@ var _ = Describe("Predicates", Ordered, func() {
 					Name:      "releaseplanadmission-origin",
 					Namespace: namespace,
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel: "true",
+						metadata.BlockReleasesLabel: "false",
 					},
 				},
 				Spec: v1alpha1.ReleasePlanAdmissionSpec{
@@ -224,7 +224,7 @@ var _ = Describe("Predicates", Ordered, func() {
 					Name:      "releaseplanadmission-status",
 					Namespace: namespace,
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel: "true",
+						metadata.BlockReleasesLabel: "false",
 					},
 				},
 				Spec: v1alpha1.ReleasePlanAdmissionSpec{
@@ -426,7 +426,6 @@ var _ = Describe("Predicates", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: nil,
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel:   "true",
 						metadata.BlockReleasesLabel: "false",
 					},
 				},
@@ -435,7 +434,6 @@ var _ = Describe("Predicates", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: nil,
 					Labels: map[string]string{
-						metadata.AutoReleaseLabel:   "false",
 						metadata.BlockReleasesLabel: "true",
 					},
 				},

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -52,22 +52,16 @@ func NewLoader() ObjectLoader {
 }
 
 // GetActiveReleasePlanAdmission returns the ReleasePlanAdmission targeted by the given ReleasePlan.
-// Only ReleasePlanAdmissions with the 'auto-release' label set to true and the 'block-releases' label
-// set to false will be searched for. If a matching ReleasePlanAdmission is not found or the List
-// operation fails, an error will be returned.
+// Only ReleasePlanAdmissions with the 'block-releases' label set to false will be searched for.
+// If a matching ReleasePlanAdmission is not found or the List operation fails, an error will be
+// returned.
 func (l *loader) GetActiveReleasePlanAdmission(ctx context.Context, cli client.Client, releasePlan *v1alpha1.ReleasePlan) (*v1alpha1.ReleasePlanAdmission, error) {
 	releasePlanAdmission, err := l.GetMatchingReleasePlanAdmission(ctx, cli, releasePlan)
 	if err != nil {
 		return nil, err
 	}
 
-	labelValue, found := releasePlanAdmission.GetLabels()[metadata.AutoReleaseLabel]
-	if found && labelValue == "false" {
-		return nil, fmt.Errorf("found ReleasePlanAdmission '%s' with auto-release label set to false",
-			releasePlanAdmission.Name)
-	}
-
-	labelValue, found = releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel]
+	labelValue, found := releasePlanAdmission.GetLabels()[metadata.BlockReleasesLabel]
 	if found && labelValue == "true" {
 		return nil, fmt.Errorf("found ReleasePlanAdmission '%s' with block-releases label set to true",
 			releasePlanAdmission.Name)

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -66,25 +66,6 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			Expect(returnedObject.Name).To(Equal(releasePlanAdmission.Name))
 		})
 
-		It("fails to return an active release plan admission if the auto release label is set to false", func() {
-			// Use a new application for this test so we don't have timing issues
-			disabledReleasePlanAdmission := releasePlanAdmission.DeepCopy()
-			disabledReleasePlanAdmission.Labels[metadata.AutoReleaseLabel] = "false"
-			disabledReleasePlanAdmission.Name = "disabled-release-plan-admission"
-			disabledReleasePlanAdmission.Spec.Applications = []string{"auto-release-test"}
-			disabledReleasePlanAdmission.ResourceVersion = ""
-			Expect(k8sClient.Create(ctx, disabledReleasePlanAdmission)).To(Succeed())
-			releasePlan.Spec.Application = "auto-release-test"
-
-			Eventually(func() bool {
-				returnedObject, err := loader.GetActiveReleasePlanAdmission(ctx, k8sClient, releasePlan)
-				return returnedObject == nil && err != nil && strings.Contains(err.Error(), "with auto-release label set to false")
-			})
-
-			releasePlan.Spec.Application = application.Name
-			Expect(k8sClient.Delete(ctx, disabledReleasePlanAdmission)).To(Succeed())
-		})
-
 		It("fails to return an active release plan admission if the block releases label is set to true", func() {
 			// Use a new application for this test so we don't have timing issues
 			disabledReleasePlanAdmission := releasePlanAdmission.DeepCopy()
@@ -633,7 +614,6 @@ var _ = Describe("Release Adapter", Ordered, func() {
 				Name:      "release-plan-admission",
 				Namespace: "default",
 				Labels: map[string]string{
-					metadata.AutoReleaseLabel:   "true",
 					metadata.BlockReleasesLabel: "false",
 				},
 			},


### PR DESCRIPTION
A previous commit (PR 791) made changes for the block-releases label to take the place of the auto-release label on ReleasePlanAdmissions. This enabled us to migrate existing ReleasePlanAdmissions to use the new label. Now that it has been done, this commit cleans up the auto-release label (and logic) on ReleasePlanAdmissions.