### PR TITLE
chore: bump static_check version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,7 +71,7 @@ jobs:
             git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
             exit 1
           fi
-      - uses: dominikh/staticcheck-action@v1.3.1
+      - uses: dominikh/staticcheck-action@v1.4.0
         with:
           version: "2025.1.1"
           install-go: false


### PR DESCRIPTION
A dependabot PR was created for this but it had no signature. I created this one to be merged.