### PR TITLE
feat: remove CODEOWNERS reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @konflux-ci/release-service-maintainers will be requested for
-# review when someone opens a pull request.
-*       @konflux-ci/release-service-maintainers


### PR DESCRIPTION
This is not needed anymore now that we are assigning PRs with the new automation.