### PR TITLE
fix: increase spot instance price

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -141,6 +141,8 @@ spec:
           value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: credentials-secret-name
           value: $(params.konflux-test-infra-secret)
+        - name: spot-increase-rate
+          value: 80
     - name: deploy-konflux
       when:
         - input: "$(tasks.check-if-e2e-irrelevant.results.result)"
@@ -339,6 +341,6 @@ spec:
         - name: e2e-log-name
           value: e2e-tests.log
         - name: cluster-provision-log-name
-          value: cluster-provision.log
+          value: kind-aws-provision.log
         - name: enable-test-results-analysis
           value: "true"


### PR DESCRIPTION
### Description

Sometimes we're hitting this error during kind cluster provisioning
```
Your Spot request price of 0.26771999999999996 is lower than the minimum required Spot request fulfillment price of 0.3724
```

For a better chance to get a cheap spot instance we need to increase the value of `spot-increase-rate` param (default is 20)


Otherwise this PR fixes the name of the file which contains the log from the aws kind provisioning task (see e.g. [here](https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com/release-service/konflux-e2e-tests-v84sd/)). it's used by test results analyzer