### PR TITLE
refactor(RELEASE-1180): use enum for pipelineType in release controller

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -350,7 +350,7 @@ func (r *Release) MarkFinalPipelineProcessed() {
 		r.Status.FinalProcessing.CompletionTime,
 		SucceededReason.String(),
 		r.Status.Target,
-		metadata.FinalPipelineType,
+		metadata.FinalPipelineType.String(),
 	)
 }
 
@@ -368,7 +368,7 @@ func (r *Release) MarkManagedCollectorsPipelineProcessed() {
 		r.Status.CollectorsProcessing.ManagedCollectorsProcessing.CompletionTime,
 		SucceededReason.String(),
 		r.Status.Target,
-		metadata.ManagedCollectorsPipelineType,
+		metadata.ManagedCollectorsPipelineType.String(),
 	)
 }
 
@@ -386,7 +386,7 @@ func (r *Release) MarkManagedPipelineProcessed() {
 		r.Status.ManagedProcessing.CompletionTime,
 		SucceededReason.String(),
 		r.Status.Target,
-		metadata.ManagedPipelineType,
+		metadata.ManagedPipelineType.String(),
 	)
 }
 
@@ -404,7 +404,7 @@ func (r *Release) MarkTenantCollectorsPipelineProcessed() {
 		r.Status.CollectorsProcessing.TenantCollectorsProcessing.CompletionTime,
 		SucceededReason.String(),
 		r.Status.Target,
-		metadata.TenantCollectorsPipelineType,
+		metadata.TenantCollectorsPipelineType.String(),
 	)
 }
 
@@ -422,7 +422,7 @@ func (r *Release) MarkTenantPipelineProcessed() {
 		r.Status.TenantProcessing.CompletionTime,
 		SucceededReason.String(),
 		r.Status.Target,
-		metadata.TenantPipelineType,
+		metadata.TenantPipelineType.String(),
 	)
 }
 
@@ -443,7 +443,7 @@ func (r *Release) MarkFinalPipelineProcessing() {
 		r.Status.FinalProcessing.StartTime,
 		ProgressingReason.String(),
 		r.Status.Target,
-		metadata.FinalPipelineType,
+		metadata.FinalPipelineType.String(),
 	)
 }
 
@@ -464,7 +464,7 @@ func (r *Release) MarkManagedCollectorsPipelineProcessing() {
 		r.Status.CollectorsProcessing.ManagedCollectorsProcessing.StartTime,
 		ProgressingReason.String(),
 		r.Status.Target,
-		metadata.ManagedPipelineType,
+		metadata.ManagedPipelineType.String(),
 	)
 }
 
@@ -485,7 +485,7 @@ func (r *Release) MarkManagedPipelineProcessing() {
 		r.Status.ManagedProcessing.StartTime,
 		ProgressingReason.String(),
 		r.Status.Target,
-		metadata.ManagedPipelineType,
+		metadata.ManagedPipelineType.String(),
 	)
 }
 
@@ -506,7 +506,7 @@ func (r *Release) MarkTenantCollectorsPipelineProcessing() {
 		r.Status.CollectorsProcessing.TenantCollectorsProcessing.StartTime,
 		ProgressingReason.String(),
 		r.Status.Target,
-		metadata.TenantCollectorsPipelineType,
+		metadata.TenantCollectorsPipelineType.String(),
 	)
 }
 
@@ -527,7 +527,7 @@ func (r *Release) MarkTenantPipelineProcessing() {
 		r.Status.TenantProcessing.StartTime,
 		ProgressingReason.String(),
 		r.Status.Target,
-		metadata.TenantPipelineType,
+		metadata.TenantPipelineType.String(),
 	)
 }
 
@@ -545,7 +545,7 @@ func (r *Release) MarkFinalPipelineProcessingFailed(message string) {
 		r.Status.FinalProcessing.CompletionTime,
 		FailedReason.String(),
 		r.Status.Target,
-		metadata.FinalPipelineType,
+		metadata.FinalPipelineType.String(),
 	)
 }
 
@@ -563,7 +563,7 @@ func (r *Release) MarkManagedCollectorsPipelineProcessingFailed(message string) 
 		r.Status.CollectorsProcessing.ManagedCollectorsProcessing.CompletionTime,
 		FailedReason.String(),
 		r.Status.Target,
-		metadata.ManagedCollectorsPipelineType,
+		metadata.ManagedCollectorsPipelineType.String(),
 	)
 }
 
@@ -581,7 +581,7 @@ func (r *Release) MarkManagedPipelineProcessingFailed(message string) {
 		r.Status.ManagedProcessing.CompletionTime,
 		FailedReason.String(),
 		r.Status.Target,
-		metadata.ManagedPipelineType,
+		metadata.ManagedPipelineType.String(),
 	)
 }
 
@@ -599,7 +599,7 @@ func (r *Release) MarkTenantCollectorsPipelineProcessingFailed(message string) {
 		r.Status.CollectorsProcessing.TenantCollectorsProcessing.CompletionTime,
 		FailedReason.String(),
 		r.Status.Target,
-		metadata.TenantCollectorsPipelineType,
+		metadata.TenantCollectorsPipelineType.String(),
 	)
 }
 
@@ -617,7 +617,7 @@ func (r *Release) MarkTenantPipelineProcessingFailed(message string) {
 		r.Status.TenantProcessing.CompletionTime,
 		FailedReason.String(),
 		r.Status.Target,
-		metadata.TenantPipelineType,
+		metadata.TenantPipelineType.String(),
 	)
 }
 

--- a/controllers/release/adapter.go
+++ b/controllers/release/adapter.go
@@ -819,7 +819,7 @@ func (a *adapter) cleanupProcessingResources(pipelineRun *tektonv1.PipelineRun, 
 }
 
 // getCollectorsPipelineRunBuilder generates a builder to use while creating a collectors PipelineRun.
-func (a *adapter) getCollectorsPipelineRunBuilder(pipelineType, namespace, url string, revision string) *utils.PipelineRunBuilder {
+func (a *adapter) getCollectorsPipelineRunBuilder(pipelineType metadata.PipelineType, namespace, url string, revision string) *utils.PipelineRunBuilder {
 	previousRelease, err := a.loader.GetPreviousRelease(a.ctx, a.client, a.release)
 	previousReleaseNamespaceName := ""
 	if err == nil && previousRelease != nil {
@@ -827,11 +827,11 @@ func (a *adapter) getCollectorsPipelineRunBuilder(pipelineType, namespace, url s
 			previousRelease.Namespace, types.Separator, previousRelease.Name)
 	}
 
-	return utils.NewPipelineRunBuilder(pipelineType, namespace).
+	return utils.NewPipelineRunBuilder(pipelineType.String(), namespace).
 		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, integrationgitops.PipelinesAsCodePrefix)).
 		WithFinalizer(metadata.ReleaseFinalizer).
 		WithLabels(map[string]string{
-			metadata.PipelinesTypeLabel:    pipelineType,
+			metadata.PipelinesTypeLabel:    pipelineType.String(),
 			metadata.ServiceNameLabel:      metadata.ServiceName,
 			metadata.ReleaseNameLabel:      a.release.Name,
 			metadata.ReleaseNamespaceLabel: a.release.Namespace,
@@ -970,12 +970,12 @@ func (a *adapter) createTenantCollectorsPipelineRun(releasePlan *v1alpha1.Releas
 // will be extracted from the given ReleasePlan. The Release's Snapshot will also be passed to the release
 // PipelineRun.
 func (a *adapter) createFinalPipelineRun(releasePlan *v1alpha1.ReleasePlan, snapshot *applicationapiv1alpha1.Snapshot) (*tektonv1.PipelineRun, error) {
-	pipelineRun, err := utils.NewPipelineRunBuilder(metadata.FinalPipelineType, releasePlan.Namespace).
+	pipelineRun, err := utils.NewPipelineRunBuilder(metadata.FinalPipelineType.String(), releasePlan.Namespace).
 		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, integrationgitops.PipelinesAsCodePrefix)).
 		WithFinalizer(metadata.ReleaseFinalizer).
 		WithLabels(map[string]string{
 			metadata.ApplicationNameLabel:  releasePlan.Spec.Application,
-			metadata.PipelinesTypeLabel:    metadata.FinalPipelineType,
+			metadata.PipelinesTypeLabel:    metadata.FinalPipelineType.String(),
 			metadata.ServiceNameLabel:      metadata.ServiceName,
 			metadata.ReleaseNameLabel:      a.release.Name,
 			metadata.ReleaseNamespaceLabel: a.release.Namespace,
@@ -1011,12 +1011,12 @@ func (a *adapter) createFinalPipelineRun(releasePlan *v1alpha1.ReleasePlan, snap
 // will be extracted from the given ReleasePlanAdmission. The Release's Snapshot will also be passed to the release
 // PipelineRun.
 func (a *adapter) createManagedPipelineRun(resources *loader.ProcessingResources) (*tektonv1.PipelineRun, error) {
-	builder := utils.NewPipelineRunBuilder(metadata.ManagedPipelineType, resources.ReleasePlanAdmission.Namespace).
+	builder := utils.NewPipelineRunBuilder(metadata.ManagedPipelineType.String(), resources.ReleasePlanAdmission.Namespace).
 		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, integrationgitops.PipelinesAsCodePrefix)).
 		WithFinalizer(metadata.ReleaseFinalizer).
 		WithLabels(map[string]string{
 			metadata.ApplicationNameLabel:  resources.ReleasePlan.Spec.Application,
-			metadata.PipelinesTypeLabel:    metadata.ManagedPipelineType,
+			metadata.PipelinesTypeLabel:    metadata.ManagedPipelineType.String(),
 			metadata.ServiceNameLabel:      metadata.ServiceName,
 			metadata.ReleaseNameLabel:      a.release.Name,
 			metadata.ReleaseNamespaceLabel: a.release.Namespace,
@@ -1065,12 +1065,12 @@ func (a *adapter) createManagedPipelineRun(resources *loader.ProcessingResources
 // will be extracted from the given ReleasePlan. The Release's Snapshot will also be passed to the release
 // PipelineRun.
 func (a *adapter) createTenantPipelineRun(releasePlan *v1alpha1.ReleasePlan, snapshot *applicationapiv1alpha1.Snapshot) (*tektonv1.PipelineRun, error) {
-	pipelineRun, err := utils.NewPipelineRunBuilder(metadata.TenantPipelineType, releasePlan.Namespace).
+	pipelineRun, err := utils.NewPipelineRunBuilder(metadata.TenantPipelineType.String(), releasePlan.Namespace).
 		WithAnnotations(metadata.GetAnnotationsWithPrefix(a.release, integrationgitops.PipelinesAsCodePrefix)).
 		WithFinalizer(metadata.ReleaseFinalizer).
 		WithLabels(map[string]string{
 			metadata.ApplicationNameLabel:  releasePlan.Spec.Application,
-			metadata.PipelinesTypeLabel:    metadata.TenantPipelineType,
+			metadata.PipelinesTypeLabel:    metadata.TenantPipelineType.String(),
 			metadata.ServiceNameLabel:      metadata.ServiceName,
 			metadata.ReleaseNameLabel:      a.release.Name,
 			metadata.ReleaseNamespaceLabel: a.release.Namespace,

--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -2487,7 +2487,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 
 		It("returns a PipelineRun with the right prefix", func() {
 			Expect(reflect.TypeOf(pipelineRun)).To(Equal(reflect.TypeOf(&tektonv1.PipelineRun{})))
-			Expect(pipelineRun.Name).To(HavePrefix(metadata.ManagedCollectorsPipelineType))
+			Expect(pipelineRun.Name).To(HavePrefix(metadata.ManagedCollectorsPipelineType.String()))
 		})
 
 		It("has the release reference", func() {
@@ -2501,7 +2501,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 		})
 
 		It("has release labels", func() {
-			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal(metadata.ManagedCollectorsPipelineType))
+			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal(metadata.ManagedCollectorsPipelineType.String()))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNameLabel]).To(Equal(adapter.release.Name))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNamespaceLabel]).To(Equal(testNamespace))
 			Expect(pipelineRun.GetLabels()[metadata.ServiceNameLabel]).To(Equal(metadata.ServiceName))
@@ -2571,7 +2571,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 
 		It("returns a PipelineRun with the right prefix", func() {
 			Expect(reflect.TypeOf(pipelineRun)).To(Equal(reflect.TypeOf(&tektonv1.PipelineRun{})))
-			Expect(pipelineRun.Name).To(HavePrefix(metadata.TenantCollectorsPipelineType))
+			Expect(pipelineRun.Name).To(HavePrefix(metadata.TenantCollectorsPipelineType.String()))
 		})
 
 		It("has the release reference", func() {
@@ -2586,7 +2586,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 		})
 
 		It("has release labels", func() {
-			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal(metadata.TenantCollectorsPipelineType))
+			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal(metadata.TenantCollectorsPipelineType.String()))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNameLabel]).To(Equal(adapter.release.Name))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNamespaceLabel]).To(Equal(testNamespace))
 			Expect(pipelineRun.GetLabels()[metadata.ServiceNameLabel]).To(Equal(metadata.ServiceName))
@@ -2741,7 +2741,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 		})
 
 		It("has release labels", func() {
-			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal(metadata.TenantPipelineType))
+			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal(metadata.TenantPipelineType.String()))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNameLabel]).To(Equal(adapter.release.Name))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNamespaceLabel]).To(Equal(testNamespace))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseSnapshotLabel]).To(Equal(adapter.release.Spec.Snapshot))
@@ -2899,7 +2899,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(pipelineRun).NotTo(BeNil())
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal(metadata.ManagedPipelineType))
+			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal(metadata.ManagedPipelineType.String()))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNameLabel]).To(Equal(adapter.release.Name))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNamespaceLabel]).To(Equal(testNamespace))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseSnapshotLabel]).To(Equal(adapter.release.Spec.Snapshot))
@@ -3186,7 +3186,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 		})
 
 		It("has release labels", func() {
-			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal(metadata.FinalPipelineType))
+			Expect(pipelineRun.GetLabels()[metadata.PipelinesTypeLabel]).To(Equal(metadata.FinalPipelineType.String()))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNameLabel]).To(Equal(adapter.release.Name))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseNamespaceLabel]).To(Equal(testNamespace))
 			Expect(pipelineRun.GetLabels()[metadata.ReleaseSnapshotLabel]).To(Equal(adapter.release.Spec.Snapshot))

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -38,7 +38,7 @@ type ObjectLoader interface {
 	GetPreviousRelease(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*v1alpha1.Release, error)
 	GetRelease(ctx context.Context, cli client.Client, name, namespace string) (*v1alpha1.Release, error)
 	GetRoleBindingFromReleaseStatusPipelineInfo(ctx context.Context, cli client.Client, pipelineInfo *v1alpha1.PipelineInfo, roleBindingType string) (*rbac.RoleBinding, error)
-	GetReleasePipelineRun(ctx context.Context, cli client.Client, release *v1alpha1.Release, pipelineType string) (*tektonv1.PipelineRun, error)
+	GetReleasePipelineRun(ctx context.Context, cli client.Client, release *v1alpha1.Release, pipelineType metadata.PipelineType) (*tektonv1.PipelineRun, error)
 	GetReleasePlan(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*v1alpha1.ReleasePlan, error)
 	GetReleaseServiceConfig(ctx context.Context, cli client.Client, name, namespace string) (*v1alpha1.ReleaseServiceConfig, error)
 	GetSnapshot(ctx context.Context, cli client.Client, release *v1alpha1.Release) (*applicationapiv1alpha1.Snapshot, error)
@@ -290,7 +290,7 @@ func (l *loader) GetRoleBindingFromReleaseStatusPipelineInfo(ctx context.Context
 
 // GetReleasePipelineRun returns the Release PipelineRun of the specified type referenced by the given Release
 // or nil if it's not found. In the case the List operation fails, an error will be returned.
-func (l *loader) GetReleasePipelineRun(ctx context.Context, cli client.Client, release *v1alpha1.Release, pipelineType string) (*tektonv1.PipelineRun, error) {
+func (l *loader) GetReleasePipelineRun(ctx context.Context, cli client.Client, release *v1alpha1.Release, pipelineType metadata.PipelineType) (*tektonv1.PipelineRun, error) {
 	if pipelineType != metadata.ManagedCollectorsPipelineType && pipelineType != metadata.ManagedPipelineType &&
 		pipelineType != metadata.TenantCollectorsPipelineType && pipelineType != metadata.TenantPipelineType && pipelineType != metadata.FinalPipelineType {
 		return nil, fmt.Errorf("cannot fetch Release PipelineRun with invalid type %s", pipelineType)
@@ -302,7 +302,7 @@ func (l *loader) GetReleasePipelineRun(ctx context.Context, cli client.Client, r
 		client.MatchingLabels{
 			metadata.ReleaseNameLabel:      release.Name,
 			metadata.ReleaseNamespaceLabel: release.Namespace,
-			metadata.PipelinesTypeLabel:    pipelineType,
+			metadata.PipelinesTypeLabel:    pipelineType.String(),
 		})
 	if err == nil && len(pipelineRuns.Items) > 0 {
 		return &pipelineRuns.Items[0], nil

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -8,6 +8,7 @@ import (
 	ecapiv1alpha1 "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/metadata"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -123,7 +124,7 @@ func (l *mockLoader) GetRoleBindingFromReleaseStatusPipelineInfo(ctx context.Con
 }
 
 // GetReleasePipelineRun returns the resource and error passed as values of the context.
-func (l *mockLoader) GetReleasePipelineRun(ctx context.Context, cli client.Client, release *v1alpha1.Release, pipelineType string) (*tektonv1.PipelineRun, error) {
+func (l *mockLoader) GetReleasePipelineRun(ctx context.Context, cli client.Client, release *v1alpha1.Release, pipelineType metadata.PipelineType) (*tektonv1.PipelineRun, error) {
 	if ctx.Value(ReleasePipelineRunContextKey) == nil {
 		return l.loader.GetReleasePipelineRun(ctx, cli, release, pipelineType)
 	}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -441,7 +441,8 @@ var _ = Describe("Release Adapter", Ordered, func() {
 
 	When("calling GetReleasePipelineRun", func() {
 		It("returns an error when called with an unexpected Pipeline type", func() {
-			returnedObject, err := loader.GetReleasePipelineRun(ctx, k8sClient, release, "foo")
+			invalidPipelineType := metadata.PipelineType("invalid-type")
+			returnedObject, err := loader.GetReleasePipelineRun(ctx, k8sClient, release, invalidPipelineType)
 			Expect(returnedObject).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid type"))
@@ -676,7 +677,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 				Labels: map[string]string{
 					metadata.ReleaseNameLabel:      release.Name,
 					metadata.ReleaseNamespaceLabel: release.Namespace,
-					metadata.PipelinesTypeLabel:    metadata.FinalPipelineType,
+					metadata.PipelinesTypeLabel:    metadata.FinalPipelineType.String(),
 				},
 				Name:      "final-pipeline-run",
 				Namespace: "default",
@@ -689,7 +690,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 				Labels: map[string]string{
 					metadata.ReleaseNameLabel:      release.Name,
 					metadata.ReleaseNamespaceLabel: release.Namespace,
-					metadata.PipelinesTypeLabel:    metadata.ManagedCollectorsPipelineType,
+					metadata.PipelinesTypeLabel:    metadata.ManagedCollectorsPipelineType.String(),
 				},
 				Name:      "managed-collectors-pipeline-run",
 				Namespace: "default",
@@ -702,7 +703,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 				Labels: map[string]string{
 					metadata.ReleaseNameLabel:      release.Name,
 					metadata.ReleaseNamespaceLabel: release.Namespace,
-					metadata.PipelinesTypeLabel:    metadata.ManagedPipelineType,
+					metadata.PipelinesTypeLabel:    metadata.ManagedPipelineType.String(),
 				},
 				Name:      "managed-pipeline-run",
 				Namespace: "default",
@@ -715,7 +716,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 				Labels: map[string]string{
 					metadata.ReleaseNameLabel:      release.Name,
 					metadata.ReleaseNamespaceLabel: release.Namespace,
-					metadata.PipelinesTypeLabel:    metadata.TenantCollectorsPipelineType,
+					metadata.PipelinesTypeLabel:    metadata.TenantCollectorsPipelineType.String(),
 				},
 				Name:      "tenant-collectors-pipeline-run",
 				Namespace: "default",
@@ -728,7 +729,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 				Labels: map[string]string{
 					metadata.ReleaseNameLabel:      release.Name,
 					metadata.ReleaseNamespaceLabel: release.Namespace,
-					metadata.PipelinesTypeLabel:    metadata.TenantPipelineType,
+					metadata.PipelinesTypeLabel:    metadata.TenantPipelineType.String(),
 				},
 				Name:      "tenant-pipeline-run",
 				Namespace: "default",

--- a/metadata/labels.go
+++ b/metadata/labels.go
@@ -18,6 +18,32 @@ package metadata
 
 import "fmt"
 
+// PipelineType represents the type of a pipeline
+type PipelineType string
+
+// String returns the string representation of the PipelineType
+func (pt PipelineType) String() string {
+	return string(pt)
+}
+
+// Pipeline type enum values
+const (
+	// ManagedCollectorsPipelineType is the value to be used in the PipelinesTypeLabel for managed collector Pipelines
+	ManagedCollectorsPipelineType PipelineType = "managed-collectors"
+
+	// TenantCollectorsPipelineType is the value to be used in the PipelinesTypeLabel for tenant collector Pipelines
+	TenantCollectorsPipelineType PipelineType = "tenant-collectors"
+
+	// FinalPipelineType is the value to be used in the PipelinesTypeLabel for final Pipelines
+	FinalPipelineType PipelineType = "final"
+
+	// ManagedPipelineType is the value to be used in the PipelinesTypeLabel for managed Pipelines
+	ManagedPipelineType PipelineType = "managed"
+
+	// TenantPipelineType is the value to be used in the PipelinesTypeLabel for tenant Pipelines
+	TenantPipelineType PipelineType = "tenant"
+)
+
 // Common constants
 const (
 	// RhtapDomain is the prefix of the application label
@@ -31,9 +57,18 @@ const (
 )
 
 // Prefixes used by the release controller package
-var (
+const (
 	// PipelinesAsCodePrefix contains the prefix applied to labels and annotations copied from Pipelines as Code resources.
 	PipelinesAsCodePrefix = "pac.test.appstudio.openshift.io"
+)
+
+// Prefixes to be used by Release Pipelines labels
+var (
+	// pipelinesLabelPrefix is the prefix of the pipelines label
+	pipelinesLabelPrefix = fmt.Sprintf("pipelines.%s", RhtapDomain)
+
+	// releaseLabelPrefix is the prefix of the release labels
+	releaseLabelPrefix = fmt.Sprintf("release.%s", RhtapDomain)
 )
 
 // Labels used by the release api package
@@ -60,34 +95,10 @@ var (
 	ReleasePlanAdmissionLabel = fmt.Sprintf("release.%s/releasePlanAdmission", RhtapDomain)
 )
 
-// Prefixes to be used by Release Pipelines labels
-var (
-	// pipelinesLabelPrefix is the prefix of the pipelines label
-	pipelinesLabelPrefix = fmt.Sprintf("pipelines.%s", RhtapDomain)
-
-	// releaseLabelPrefix is the prefix of the release labels
-	releaseLabelPrefix = fmt.Sprintf("release.%s", RhtapDomain)
-)
-
 // Labels to be used within Release PipelineRuns
 var (
 	// ApplicationNameLabel is the label used to specify the application associated with the PipelineRun
 	ApplicationNameLabel = fmt.Sprintf("%s/%s", RhtapDomain, "application")
-
-	// ManagedCollectorsPipelineType is the value to be used in the PipelinesTypeLabel for managed collector Pipelines
-	ManagedCollectorsPipelineType = "managed-collectors"
-
-	// TenantCollectorsPipelineType is the value to be used in the PipelinesTypeLabel for tenant collector Pipelines
-	TenantCollectorsPipelineType = "tenant-collectors"
-
-	// FinalPipelineType is the value to be used in the PipelinesTypeLabel for final Pipelines
-	FinalPipelineType = "final"
-
-	// ManagedPipelineType is the value to be used in the PipelinesTypeLabel for managed Pipelines
-	ManagedPipelineType = "managed"
-
-	// TenantPipelineType is the value to be used in the PipelinesTypeLabel for tenant Pipelines
-	TenantPipelineType = "tenant"
 
 	// PipelinesTypeLabel is the label used to describe the type of pipeline
 	PipelinesTypeLabel = fmt.Sprintf("%s/%s", pipelinesLabelPrefix, "type")

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -33,6 +33,16 @@ func TestMetadata(t *testing.T) {
 
 var _ = Describe("Metadata", func() {
 
+	Context("PipelineType enum", func() {
+		It("should return correct string representation", func() {
+			Expect(ManagedCollectorsPipelineType.String()).To(Equal("managed-collectors"))
+			Expect(TenantCollectorsPipelineType.String()).To(Equal("tenant-collectors"))
+			Expect(FinalPipelineType.String()).To(Equal("final"))
+			Expect(ManagedPipelineType.String()).To(Equal("managed"))
+			Expect(TenantPipelineType.String()).To(Equal("tenant"))
+		})
+	})
+
 	Context("addEntries function", func() {
 		When("called with an empty destination map", func() {
 			src := map[string]string{

--- a/tekton/predicates_test.go
+++ b/tekton/predicates_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Predicates", Ordered, func() {
 		It("should return true when an updated event is received for a succeeded managed PipelineRun", func() {
 			var releasePipelineRun *v1.PipelineRun
 			releasePipelineRun, err = utils.NewPipelineRunBuilder("pipeline-run", "default").
-				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.ManagedPipelineType}).
+				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.ManagedPipelineType.String()}).
 				Build()
 			Expect(err).NotTo(HaveOccurred())
 			contextEvent := event.UpdateEvent{

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -32,11 +32,11 @@ func isReleasePipelineRun(object client.Object) bool {
 
 	labelValue, found := object.GetLabels()[metadata.PipelinesTypeLabel]
 
-	return found && (labelValue == metadata.TenantCollectorsPipelineType ||
-		labelValue == metadata.ManagedCollectorsPipelineType ||
-		labelValue == metadata.FinalPipelineType ||
-		labelValue == metadata.ManagedPipelineType ||
-		labelValue == metadata.TenantPipelineType)
+	return found && (labelValue == metadata.TenantCollectorsPipelineType.String() ||
+		labelValue == metadata.ManagedCollectorsPipelineType.String() ||
+		labelValue == metadata.FinalPipelineType.String() ||
+		labelValue == metadata.ManagedPipelineType.String() ||
+		labelValue == metadata.TenantPipelineType.String())
 }
 
 // hasPipelineSucceeded returns a boolean indicating whether the PipelineRun succeeded or not.

--- a/tekton/utils_test.go
+++ b/tekton/utils_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Utils", Ordered, func() {
 
 		It("should return true when the PipelineRun is of type 'tenant-collectors'", func() {
 			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
-				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.TenantCollectorsPipelineType}).
+				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.TenantCollectorsPipelineType.String()}).
 				Build()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(isReleasePipelineRun(pipelineRun)).To(BeTrue())
@@ -41,7 +41,7 @@ var _ = Describe("Utils", Ordered, func() {
 
 		It("should return true when the PipelineRun is of type 'managed-collectors'", func() {
 			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
-				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.ManagedCollectorsPipelineType}).
+				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.ManagedCollectorsPipelineType.String()}).
 				Build()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(isReleasePipelineRun(pipelineRun)).To(BeTrue())
@@ -49,7 +49,7 @@ var _ = Describe("Utils", Ordered, func() {
 
 		It("should return true when the PipelineRun is of type 'final'", func() {
 			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
-				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.FinalPipelineType}).
+				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.FinalPipelineType.String()}).
 				Build()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(isReleasePipelineRun(pipelineRun)).To(BeTrue())
@@ -57,7 +57,7 @@ var _ = Describe("Utils", Ordered, func() {
 
 		It("should return true when the PipelineRun is of type 'managed'", func() {
 			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
-				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.ManagedPipelineType}).
+				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.ManagedPipelineType.String()}).
 				Build()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(isReleasePipelineRun(pipelineRun)).To(BeTrue())
@@ -65,7 +65,7 @@ var _ = Describe("Utils", Ordered, func() {
 
 		It("should return true when the PipelineRun is of type 'tenant'", func() {
 			pipelineRun, err := utils.NewPipelineRunBuilder("pipeline-run", "default").
-				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.TenantPipelineType}).
+				WithLabels(map[string]string{metadata.PipelinesTypeLabel: metadata.TenantPipelineType.String()}).
 				Build()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(isReleasePipelineRun(pipelineRun)).To(BeTrue())


### PR DESCRIPTION
Instead of having a bunch of strings for the pipelineType and comparing against it, we should use an enum for it. This comes from [#549](https://github.com/konflux-ci/release-service/pull/549#discussion_r1764942351)

It would be cleaner and less error prone.

##Relevant Jira
[RELEASE-1180](https://issues.redhat.com/browse/RELEASE-1180)

Signed-off-by: elenagerman [elgerman@redhat.com](mailto:elgerman@redhat.com)
