### PR TITLE
fix(RELEASE-2681): authenticate GitHub branch resolution and fail on rate limits

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -85,5 +85,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: release-service-github-token
+              optional: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/git/references.go
+++ b/git/references.go
@@ -19,6 +19,8 @@ package git
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -26,6 +28,14 @@ import (
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	// GitHubTokenEnvVar is the environment variable used to authenticate GitHub API
+	// requests when resolving branch names to commit SHAs.
+	GitHubTokenEnvVar = "GITHUB_TOKEN" // #nosec G101 -- env var name, not a credential
 )
 
 // Sentinel errors for git configuration problems that won't resolve on retry.
@@ -36,15 +46,22 @@ var (
 	ErrBranchNotFound = errors.New("branch not found")
 )
 
-var shaRegex = regexp.MustCompile("^[a-f0-9]{40}$")
+var (
+	shaRegex       = regexp.MustCompile("^[a-f0-9]{40}$")
+	gitLog         = ctrl.Log.WithName("git")
+	listRemoteRefs = func(remote *git.Remote, opts *git.ListOptions) ([]*plumbing.Reference, error) {
+		return remote.List(opts)
+	}
+	retryDelay = time.Sleep
+)
 
 // IsSHA checks if a reference is already a 40-character SHA (optimized)
 func IsSHA(ref string) bool {
 	return shaRegex.MatchString(ref)
 }
 
-// isRateLimitError checks if an error is a rate limit error
-func isRateLimitError(err error) bool {
+// IsRateLimitError reports whether err looks like a GitHub / git rate-limit failure.
+func IsRateLimitError(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -73,8 +90,52 @@ func ValidateGitResolverConfig(url, revision, pathInRepo string) error {
 	return nil
 }
 
-// ResolveBranchToSHA resolves a git branch reference to a commit SHA using go-git
-func ResolveBranchToSHA(repoURL, revision string) (string, error) {
+// HasGitHubToken reports whether GITHUB_TOKEN is set in the environment.
+func HasGitHubToken() bool {
+	return strings.TrimSpace(os.Getenv(GitHubTokenEnvVar)) != ""
+}
+
+// IsGitHubURL reports whether repoURL points at a GitHub repository over HTTPS.
+func IsGitHubURL(repoURL string) bool {
+	parsed, err := url.Parse(repoURL)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Scheme, "https") &&
+		strings.EqualFold(parsed.Hostname(), "github.com")
+}
+
+func remoteListOptions(repoURL string) *git.ListOptions {
+	opts := &git.ListOptions{}
+	if IsGitHubURL(repoURL) {
+		if token := strings.TrimSpace(os.Getenv(GitHubTokenEnvVar)); token != "" {
+			opts.Auth = &githttp.BasicAuth{
+				Username: "x-access-token",
+				Password: token,
+			}
+		}
+	}
+	return opts
+}
+
+// RedactURLCredentials returns repoURL with userinfo stripped so credentials are
+// not written to controller logs. Unparseable URLs are replaced with a fixed
+// placeholder so a malformed credential-bearing string is never logged raw.
+func RedactURLCredentials(repoURL string) string {
+	parsed, err := url.Parse(repoURL)
+	if err != nil {
+		return "<invalid repository URL>"
+	}
+	if parsed.User == nil {
+		return repoURL
+	}
+	parsed.User = nil
+	return parsed.String()
+}
+
+// ResolveBranchToSHA resolves a git branch reference to a commit SHA using go-git.
+// The package-level variable form allows tests to stub remote resolution.
+var ResolveBranchToSHA = func(repoURL, revision string) (string, error) {
 	if repoURL == "" || revision == "" {
 		return "", fmt.Errorf("%w: repository URL and revision cannot be empty", ErrInvalidGitResolverConfig)
 	}
@@ -84,7 +145,7 @@ func ResolveBranchToSHA(repoURL, revision string) (string, error) {
 	}
 
 	gitURL := repoURL
-	if strings.HasPrefix(repoURL, "https://github.com/") && !strings.HasSuffix(repoURL, ".git") {
+	if IsGitHubURL(repoURL) && !strings.HasSuffix(strings.ToLower(repoURL), ".git") {
 		gitURL = repoURL + ".git"
 	}
 
@@ -95,26 +156,29 @@ func ResolveBranchToSHA(repoURL, revision string) (string, error) {
 
 	maxRetries := 3
 	baseDelay := 2 * time.Second
+	listOpts := remoteListOptions(repoURL)
 
 	var refs []*plumbing.Reference
 	var err error
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		refs, err = remote.List(&git.ListOptions{})
+		refs, err = listRemoteRefs(remote, listOpts)
 		if err == nil {
 			break
 		}
 
-		if !isRateLimitError(err) {
+		if !IsRateLimitError(err) {
 			return "", fmt.Errorf("remote repository access failed: %w", err)
 		}
 
 		if attempt == maxRetries {
+			gitLog.Error(err, "failed to resolve branch to SHA after rate limit retries",
+				"url", RedactURLCredentials(repoURL), "revision", revision, "authenticated", listOpts.Auth != nil)
 			return "", fmt.Errorf("remote repository access failed after %d retries (rate limited): %w", maxRetries, err)
 		}
 
 		delay := baseDelay * time.Duration(1<<uint(attempt))
-		time.Sleep(delay)
+		retryDelay(delay)
 	}
 
 	refName := plumbing.ReferenceName("refs/heads/" + revision)

--- a/git/references_test.go
+++ b/git/references_test.go
@@ -19,6 +19,11 @@ package git
 import (
 	"errors"
 	"fmt"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -45,31 +50,31 @@ var _ = Describe("Git References", func() {
 		})
 	})
 
-	Describe("isRateLimitError", func() {
+	Describe("IsRateLimitError", func() {
 		It("should return false for nil error", func() {
-			Expect(isRateLimitError(nil)).To(BeFalse())
+			Expect(IsRateLimitError(nil)).To(BeFalse())
 		})
 
 		It("should return true for rate limit errors", func() {
 			err := fmt.Errorf("rate limit exceeded")
-			Expect(isRateLimitError(err)).To(BeTrue())
+			Expect(IsRateLimitError(err)).To(BeTrue())
 
 			err = fmt.Errorf("API rate limit")
-			Expect(isRateLimitError(err)).To(BeTrue())
+			Expect(IsRateLimitError(err)).To(BeTrue())
 
 			err = fmt.Errorf("status code 403")
-			Expect(isRateLimitError(err)).To(BeTrue())
+			Expect(IsRateLimitError(err)).To(BeTrue())
 		})
 
 		It("should return false for other errors", func() {
 			err := fmt.Errorf("authentication required")
-			Expect(isRateLimitError(err)).To(BeFalse())
+			Expect(IsRateLimitError(err)).To(BeFalse())
 
 			err = fmt.Errorf("connection refused")
-			Expect(isRateLimitError(err)).To(BeFalse())
+			Expect(IsRateLimitError(err)).To(BeFalse())
 
 			err = fmt.Errorf("some other error")
-			Expect(isRateLimitError(err)).To(BeFalse())
+			Expect(IsRateLimitError(err)).To(BeFalse())
 		})
 	})
 
@@ -148,6 +153,103 @@ var _ = Describe("Git References", func() {
 			err := ValidateGitResolverConfig("", "", "")
 			Expect(err).To(HaveOccurred())
 			Expect(errors.Is(err, ErrInvalidGitResolverConfig)).To(BeTrue())
+		})
+	})
+
+	Describe("HasGitHubToken", func() {
+		It("should return false when GITHUB_TOKEN is unset", func() {
+			GinkgoT().Setenv(GitHubTokenEnvVar, "")
+			Expect(HasGitHubToken()).To(BeFalse())
+		})
+
+		It("should return false when GITHUB_TOKEN is whitespace-only", func() {
+			GinkgoT().Setenv(GitHubTokenEnvVar, "   ")
+			Expect(HasGitHubToken()).To(BeFalse())
+		})
+
+		It("should return true when GITHUB_TOKEN is set", func() {
+			GinkgoT().Setenv(GitHubTokenEnvVar, "test-token")
+			Expect(HasGitHubToken()).To(BeTrue())
+		})
+	})
+
+	Describe("IsGitHubURL", func() {
+		It("should return true for GitHub HTTPS URLs", func() {
+			Expect(IsGitHubURL("https://github.com/org/repo")).To(BeTrue())
+			Expect(IsGitHubURL("https://github.com/org/repo.git")).To(BeTrue())
+			Expect(IsGitHubURL("HTTPS://GitHub.com/org/repo.git")).To(BeTrue())
+		})
+
+		It("should return false for non-GitHub and non-HTTPS GitHub URLs", func() {
+			Expect(IsGitHubURL("http://github.com/org/repo.git")).To(BeFalse())
+			Expect(IsGitHubURL("https://gitlab.com/org/repo.git")).To(BeFalse())
+			Expect(IsGitHubURL("https://bitbucket.org/org/repo.git")).To(BeFalse())
+			Expect(IsGitHubURL("://bad")).To(BeFalse())
+		})
+	})
+
+	Describe("RedactURLCredentials", func() {
+		It("should strip userinfo from URLs", func() {
+			Expect(RedactURLCredentials("https://user:token@github.com/org/repo.git")).
+				To(Equal("https://github.com/org/repo.git"))
+		})
+
+		It("should leave URLs without credentials unchanged", func() {
+			Expect(RedactURLCredentials("https://github.com/org/repo.git")).
+				To(Equal("https://github.com/org/repo.git"))
+		})
+
+		It("should return a placeholder for unparseable URLs", func() {
+			Expect(RedactURLCredentials("://user:token@host/repo")).
+				To(Equal("<invalid repository URL>"))
+		})
+	})
+
+	Describe("remoteListOptions", func() {
+		It("should not set auth when GITHUB_TOKEN is unset", func() {
+			GinkgoT().Setenv(GitHubTokenEnvVar, "")
+			opts := remoteListOptions("https://github.com/org/repo.git")
+			Expect(opts.Auth).To(BeNil())
+		})
+
+		It("should set GitHub basic auth when GITHUB_TOKEN is set for a GitHub URL", func() {
+			GinkgoT().Setenv(GitHubTokenEnvVar, "test-token")
+			opts := remoteListOptions("https://github.com/org/repo.git")
+			Expect(opts.Auth).NotTo(BeNil())
+
+			basicAuth, ok := opts.Auth.(*githttp.BasicAuth)
+			Expect(ok).To(BeTrue())
+			Expect(basicAuth.Username).To(Equal("x-access-token"))
+			Expect(basicAuth.Password).To(Equal("test-token"))
+		})
+
+		It("should not set auth for non-GitHub URLs even when GITHUB_TOKEN is set", func() {
+			GinkgoT().Setenv(GitHubTokenEnvVar, "test-token")
+			opts := remoteListOptions("https://gitlab.com/org/repo.git")
+			Expect(opts.Auth).To(BeNil())
+		})
+	})
+
+	Describe("ResolveBranchToSHA with mocked remote list", func() {
+		BeforeEach(func() {
+			originalListRemoteRefs := listRemoteRefs
+			originalRetryDelay := retryDelay
+			retryDelay = func(time.Duration) {}
+			DeferCleanup(func() {
+				listRemoteRefs = originalListRemoteRefs
+				retryDelay = originalRetryDelay
+			})
+		})
+
+		It("should return an error when rate limited instead of falling back silently", func() {
+			listRemoteRefs = func(_ *git.Remote, _ *git.ListOptions) ([]*plumbing.Reference, error) {
+				return nil, fmt.Errorf("API rate limit exceeded")
+			}
+
+			_, err := ResolveBranchToSHA("https://github.com/octocat/Hello-World.git", "master")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("remote repository access failed"))
+			Expect(err.Error()).To(ContainSubstring("rate limited"))
 		})
 	})
 })

--- a/tekton/utils/pipeline_run_builder.go
+++ b/tekton/utils/pipeline_run_builder.go
@@ -29,11 +29,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/konflux-ci/release-service/git"
 )
+
+var pipelineRunBuilderLog = ctrl.Log.WithName("pipeline-run-builder")
 
 type PipelineRunBuilder struct {
 	err         *multierror.Error
@@ -239,8 +242,17 @@ func (b *PipelineRunBuilder) WithPipelineRef(pipelineRef *tektonv1.PipelineRef) 
 
 		resolvedSHA, err := git.ResolveBranchToSHA(gitURL, revision)
 		if err != nil {
-			if strings.Contains(err.Error(), "authentication required") ||
-				strings.Contains(err.Error(), "remote repository access failed") {
+			// RELEASE-2681: never fall back on rate limits — that was passing branch names as SHAs.
+			// Also fail when a GitHub token is configured but resolution still fails (bad/expired token).
+			failHard := git.IsRateLimitError(err) || (git.IsGitHubURL(gitURL) && git.HasGitHubToken())
+			canFallback := !failHard &&
+				(strings.Contains(err.Error(), "authentication required") ||
+					strings.Contains(err.Error(), "remote repository access failed"))
+			if canFallback {
+				// RELEASE-1720: private repos / environments where go-git cannot list refs (e.g. kind
+				// clusters with custom TLS CAs) may still resolve via Tekton's git clone.
+				pipelineRunBuilderLog.Info("could not resolve git revision to SHA, using branch name",
+					"url", git.RedactURLCredentials(gitURL), "revision", revision, "error", err.Error())
 				resolvedSHA = revision
 			} else {
 				b.err = multierror.Append(b.err, fmt.Errorf("git resolution failed: %w", err))

--- a/tekton/utils/pipeline_run_builder_test.go
+++ b/tekton/utils/pipeline_run_builder_test.go
@@ -27,6 +27,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/konflux-ci/release-service/git"
 )
 
 var _ = Describe("PipelineRun builder", func() {
@@ -516,6 +518,124 @@ var _ = Describe("PipelineRun builder", func() {
 			_, err := builder.Build()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("git resolution failed"))
+		})
+
+		It("falls back to the branch name on non-rate-limit remote access errors when no GitHub token is set", func() {
+			// Kind E2E clusters often hit TLS/CA errors from go-git; Tekton can still clone.
+			GinkgoT().Setenv(git.GitHubTokenEnvVar, "")
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+
+			pipelineRef := &PipelineRef{
+				Resolver: "git",
+				Params: []Param{
+					{
+						Name:  "url",
+						Value: "https://release-service-git-test.invalid/org/repo.git",
+					},
+					{
+						Name:  "revision",
+						Value: "main",
+					},
+					{
+						Name:  "pathInRepo",
+						Value: "pipelines/release.yaml",
+					},
+				},
+			}
+
+			builder.WithPipelineRef(pipelineRef.ToTektonPipelineRef())
+
+			pipelineRun, err := builder.Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			var taskGitRevision string
+			for _, param := range pipelineRun.Spec.Params {
+				if param.Name == "taskGitRevision" {
+					taskGitRevision = param.Value.StringVal
+				}
+			}
+			Expect(taskGitRevision).To(Equal("main"))
+		})
+
+		It("fails instead of falling back to branch name on rate limit errors", func() {
+			original := git.ResolveBranchToSHA
+			DeferCleanup(func() { git.ResolveBranchToSHA = original })
+			GinkgoT().Setenv(git.GitHubTokenEnvVar, "")
+			git.ResolveBranchToSHA = func(repoURL, revision string) (string, error) {
+				return "", fmt.Errorf("remote repository access failed after 3 retries (rate limited): API rate limit exceeded")
+			}
+
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			pipelineRef := &PipelineRef{
+				Resolver: "git",
+				Params: []Param{
+					{Name: "url", Value: "https://github.com/org/repo.git"},
+					{Name: "revision", Value: "production"},
+					{Name: "pathInRepo", Value: "pipelines/release.yaml"},
+				},
+			}
+
+			builder.WithPipelineRef(pipelineRef.ToTektonPipelineRef())
+			_, err := builder.Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("git resolution failed"))
+			Expect(err.Error()).To(ContainSubstring("rate limited"))
+		})
+
+		It("fails when a GitHub token is set but authentication is rejected", func() {
+			original := git.ResolveBranchToSHA
+			DeferCleanup(func() { git.ResolveBranchToSHA = original })
+			GinkgoT().Setenv(git.GitHubTokenEnvVar, "bad-token")
+			git.ResolveBranchToSHA = func(repoURL, revision string) (string, error) {
+				return "", fmt.Errorf("authentication required")
+			}
+
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			pipelineRef := &PipelineRef{
+				Resolver: "git",
+				Params: []Param{
+					{Name: "url", Value: "https://github.com/org/repo.git"},
+					{Name: "revision", Value: "production"},
+					{Name: "pathInRepo", Value: "pipelines/release.yaml"},
+				},
+			}
+
+			builder.WithPipelineRef(pipelineRef.ToTektonPipelineRef())
+			_, err := builder.Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("git resolution failed"))
+			Expect(err.Error()).To(ContainSubstring("authentication required"))
+		})
+
+		It("falls back to the branch name on authentication errors when no GitHub token is set", func() {
+			original := git.ResolveBranchToSHA
+			DeferCleanup(func() { git.ResolveBranchToSHA = original })
+			GinkgoT().Setenv(git.GitHubTokenEnvVar, "")
+			git.ResolveBranchToSHA = func(repoURL, revision string) (string, error) {
+				return "", fmt.Errorf("authentication required")
+			}
+
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			pipelineRef := &PipelineRef{
+				Resolver: "git",
+				Params: []Param{
+					{Name: "url", Value: "https://github.com/org/private-repo.git"},
+					{Name: "revision", Value: "main"},
+					{Name: "pathInRepo", Value: "pipelines/release.yaml"},
+				},
+			}
+
+			builder.WithPipelineRef(pipelineRef.ToTektonPipelineRef())
+			pipelineRun, err := builder.Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			var taskGitRevision string
+			for _, param := range pipelineRun.Spec.Params {
+				if param.Name == "taskGitRevision" {
+					taskGitRevision = param.Value.StringVal
+				}
+			}
+			Expect(taskGitRevision).To(Equal("main"))
 		})
 	})
 


### PR DESCRIPTION
## Summary
Fixes silent fallback to branch names (e.g. `production`) when `ResolveBranchToSHA` fails due to GitHub rate limiting.
## Changes
- **`git/references.go`**: authenticate `remote.List()` with `GITHUB_TOKEN` (`x-access-token`); log rate-limit exhaustion
- **`tekton/utils/pipeline_run_builder.go`**: stop falling back on `remote repository access failed`; only keep auth fallback for `authentication required`, with logging
- **`config/manager/manager.yaml`**: optional `GITHUB_TOKEN` from secret `release-service-github-token` / key `token`
## Tests
- Unit tests for token auth and mocked rate-limit error path

## Jira
[RELEASE-2681](https://redhat.atlassian.net/browse/RELEASE-2681)

[RELEASE-2681]: https://redhat.atlassian.net/browse/RELEASE-2681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ