### PR TITLE
test(loader): fix flaky GetReleasePipelineRunAttempt test

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -787,17 +787,20 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			retryPipelineRun2.Labels[metadata.ReleaseAttemptLabel] = "2"
 			Expect(k8sClient.Create(ctx, retryPipelineRun2)).To(Succeed())
 
-			returnedObject, err := loader.GetReleasePipelineRunAttempt(ctx, k8sClient, release, 0)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(returnedObject.Name).To(Equal(managedPipelineRun.Name))
+			Eventually(func() bool {
+				returnedObject, err := loader.GetReleasePipelineRunAttempt(ctx, k8sClient, release, 0)
+				return err == nil && returnedObject != nil && returnedObject.Name == managedPipelineRun.Name
+			}).Should(BeTrue())
 
-			returnedObject, err = loader.GetReleasePipelineRunAttempt(ctx, k8sClient, release, 1)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(returnedObject.Name).To(Equal(retryPipelineRun1.Name))
+			Eventually(func() bool {
+				returnedObject, err := loader.GetReleasePipelineRunAttempt(ctx, k8sClient, release, 1)
+				return err == nil && returnedObject != nil && returnedObject.Name == retryPipelineRun1.Name
+			}).Should(BeTrue())
 
-			returnedObject, err = loader.GetReleasePipelineRunAttempt(ctx, k8sClient, release, 2)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(returnedObject.Name).To(Equal(retryPipelineRun2.Name))
+			Eventually(func() bool {
+				returnedObject, err := loader.GetReleasePipelineRunAttempt(ctx, k8sClient, release, 2)
+				return err == nil && returnedObject != nil && returnedObject.Name == retryPipelineRun2.Name
+			}).Should(BeTrue())
 
 			Expect(k8sClient.Delete(ctx, retryPipelineRun1)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, retryPipelineRun2)).To(Succeed())


### PR DESCRIPTION
## Summary
- `GetReleasePipelineRunAttempt` test created PipelineRuns and
  immediately asserted on the lookup result via the cached client,
  racing the informer cache sync
- when the cache hadn't observed the create yet, the lookup returned
  nil and the test panicked on a nil pointer dereference instead of
  failing cleanly
- this has been failing roughly half of all PR CI runs over the last
  day, unrelated to the PRs' own changes, e.g.
  https://github.com/konflux-ci/release-service/pull/1848
- wraps each assertion in `Eventually()`, matching the pattern
  already used elsewhere in this suite for cache-backed reads

## Test plan
- [x] `go test ./loader/...` passes
- [x] ran the loader suite 5x in a row locally with no failures
  (previously flaky roughly 50% of the time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)