### PR TITLE
Update codecov.yml: add ignore patterns for non-code files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,13 @@ codecov:
 ignore:
   - "api/v1alpha1/zz_generated.deepcopy.go" # generated file
   - "e2e-tests/**"
+  - ".agents/**"
+  - ".claude/**"
+  - ".cursor/**"
+  - "skills/**"
+  - "docs/**"
+  - "*.md"
+  - "*.toml"
 
 coverage:
   status:


### PR DESCRIPTION
## Summary

Adds ignore patterns to `codecov.yml` for non-executable files that inflate the coverage denominator:

- `.agents/**` — AI agent configurations
- `.claude/**` — Claude AI workspace settings
- `.cursor/**` — Cursor AI settings
- `skills/**` — AI skill definitions
- `docs/**` — Documentation files
- `*.md` — Markdown files (README, AGENTS.md, etc.)
- `*.toml` — TOML configuration files

Existing ignore patterns (`zz_generated.deepcopy.go`, `e2e-tests/**`) are preserved.

## Why

Non-executable files (Markdown, TOML, docs) are counted as "uncovered lines" by Codecov, dragging down patch coverage even though they can't be tested. This was identified as the primary driver of the 13.1% patch coverage drop in the Jul 20-26 weekly report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)