### PR TITLE
chore(RELEASE-2436): migrate quay pipeline to operator based deploy

### DIFF
--- a/e2e-tests/tests/release/service/final_pipeline_finalizer_removed.go
+++ b/e2e-tests/tests/release/service/final_pipeline_finalizer_removed.go
@@ -122,14 +122,18 @@ func setupFinalPipelineFinalizerSuite() {
 		ecPolicyName := "ffinalizer-policy-" + util.GenerateRandomString(4)
 		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		gomega.Expect(defaultEcPolicy.Spec.Sources).ToNot(gomega.BeEmpty(), "default EC policy has no sources")
+
+		source := defaultEcPolicy.Spec.Sources[0]
+		source.Config = &ecp.SourceConfig{
+			Include: []string{"@slsa3"},
+			Exclude: []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+		}
+
 		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
 			Description: "Red Hat's enterprise requirements",
 			PublicKey:   fmt.Sprintf("k8s://%s/%s", m.managedNs, constants.PublicSecretNameAuth),
-			Sources:     defaultEcPolicy.Spec.Sources,
-			Configuration: &ecp.EnterpriseContractPolicyConfiguration{
-				Collections: []string{"@slsa3"},
-				Exclude:     []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
-			},
+			Sources:     []ecp.Source{source},
 		}
 		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, m.managedNs, defaultEcPolicySpec)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)

--- a/e2e-tests/tests/release/service/happy_path.go
+++ b/e2e-tests/tests/release/service/happy_path.go
@@ -78,15 +78,18 @@ var _ = ginkgo.Describe("Release service happy path", releasecommon.LabelHappyPa
 
 		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		gomega.Expect(defaultEcPolicy.Spec.Sources).ToNot(gomega.BeEmpty(), "default EC policy has no sources")
+
+		source := defaultEcPolicy.Spec.Sources[0]
+		source.Config = &ecp.SourceConfig{
+			Include: []string{"@slsa3"},
+			Exclude: []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+		}
 
 		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
 			Description: "Red Hat's enterprise requirements",
 			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, constants.PublicSecretNameAuth),
-			Sources:     defaultEcPolicy.Spec.Sources,
-			Configuration: &ecp.EnterpriseContractPolicyConfiguration{
-				Collections: []string{"@slsa3"},
-				Exclude:     []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
-			},
+			Sources:     []ecp.Source{source},
 		}
 		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)

--- a/e2e-tests/tests/release/service/pipeline_creation_error_surfaced.go
+++ b/e2e-tests/tests/release/service/pipeline_creation_error_surfaced.go
@@ -81,15 +81,18 @@ var _ = ginkgo.Describe("Managed PipelineRun creation denial is surfaced on Rele
 
 		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		gomega.Expect(defaultEcPolicy.Spec.Sources).ToNot(gomega.BeEmpty(), "default EC policy has no sources")
+
+		source := defaultEcPolicy.Spec.Sources[0]
+		source.Config = &ecp.SourceConfig{
+			Include: []string{"@slsa3"},
+			Exclude: []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+		}
 
 		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
 			Description: "Red Hat's enterprise requirements",
 			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, constants.PublicSecretNameAuth),
-			Sources:     defaultEcPolicy.Spec.Sources,
-			Configuration: &ecp.EnterpriseContractPolicyConfiguration{
-				Collections: []string{"@slsa3"},
-				Exclude:     []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
-			},
+			Sources:     []ecp.Source{source},
 		}
 		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)

--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -41,6 +41,15 @@ spec:
       description: "URL to the artifact browser deployment. If provided, a link will be added to PR comments."
       default: ""
       type: string
+    - name: konflux-ready-timeout
+      description: Timeout for waiting on the Konflux CR Ready condition.
+      type: string
+      default: 30m
+    - name: konflux-cr-configmap
+      description: >-
+        ConfigMap in the pipeline namespace containing the Konflux CR to apply.
+      type: string
+      default: konflux-deploy-cr
 
   tasks:
     # ──────────────────────────────────────────────────────────────────────────
@@ -143,34 +152,41 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog
+            value: https://github.com/konflux-ci/konflux-ci.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
+            value: .tekton/tasks/deploy-konflux/task.yaml
       params:
         - name: cluster-access-secret
           value: kfg-$(context.pipelineRun.name)
-        - name: component-name
-          value: release-service
-        - name: component-pr-owner
-          value: $(tasks.test-metadata.results.pull-request-author)
-        - name: component-pr-sha
-          value: $(tasks.test-metadata.results.git-revision)
-        - name: component-pr-source-branch
-          value: $(tasks.test-metadata.results.source-repo-branch)
-        - name: oci-ref
-          value: $(params.oci-container-repo):$(context.pipelineRun.name)
-        - name: credentials-secret-name
+        - name: git-url
+          value: https://github.com/konflux-ci/konflux-ci.git
+        - name: revision
+          value: main
+        - name: konflux-ready-timeout
+          value: $(params.konflux-ready-timeout)
+        - name: konflux-cr-configmap
+          value: $(params.konflux-cr-configmap)
+        - name: konflux-cr-configmap-key
+          value: konflux-cr.yaml
+        - name: oci-container-repo
+          value: $(params.oci-container-repo)
+        - name: oci-container-repo-credentials-secret
           value: $(params.konflux-test-infra-secret)
-        - name: component-image-repository
-          value: $(tasks.test-metadata.results.instrumented-container-repo)
-        - name: component-image-tag
-          value: $(tasks.test-metadata.results.instrumented-container-tag)
-        - name: oci-credentials
-          value: konflux-test-infra
-        - name: build-credentials
-          value: konflux-e2e-secrets
+        - name: pipeline-run-name
+          value: $(context.pipelineRun.name)
+        - name: overrides-yaml
+          value: |
+            - name: release
+              git:
+                - sourceRepo: konflux-ci/release-service
+                  remote:
+                    repo: "$(tasks.test-metadata.results.git-url)"
+                    ref: "$(tasks.test-metadata.results.git-revision)"
+              images:
+                - orig: quay.io/konflux-ci/release-service
+                  replacement: "$(tasks.test-metadata.results.instrumented-container-repo):$(tasks.test-metadata.results.instrumented-container-tag)"
 
     # ──────────────────────────────────────────────────────────────────────────
     # E2E tests: clone release-service repo and run Ginkgo suite


### PR DESCRIPTION


## Summary

Replace the legacy konflux-ci task with the new operator-based deploy-konflux task in konflux-e2e-tests-pipeline.

Updated e2e tests to stop using the deprecated EnterpriseContractPolicyConfiguration moved include/exclude to Source.Config and also dropped Collections to use Include.

Source:
https://github.com/conforma/crds/blob/api/v0.1.11/api/v1alpha1/enterprisecontractpolicy_types.go#L148
https://github.com/conforma/crds/blob/api/v0.1.11/api/v1alpha1/enterprisecontractpolicy_types.go#L160

Assisted-by: Claude

## Related Issues
https://redhat.atlassian.net/browse/RELEASE-2436

## Testing

- [ ] Tests added/updated
- [ ] All tests pass (`make test`)
- [ ] Changes verified locally

## Checklist

- [ ] Code follows Kubernetes coding conventions
- [ ] Commit messages follow conventional format: `type(RELEASE-NNNN): description`
- [ ] Documentation updated if needed
- [ ] Generated manifests updated (`make manifests generate`)
