### PR TITLE
test(RELEASE-2683): add e2e for managed pipeline retries

### DIFF
--- a/controllers/release/adapter_test.go
+++ b/controllers/release/adapter_test.go
@@ -5433,7 +5433,7 @@ var _ = Describe("Release adapter", Ordered, func() {
 			Expect(appliedMitigation.TaskTimeout).To(Equal("20m0s"))
 		})
 
-		It("should bump the pipeline timeout for a PipelineRunTimeout failure", func() {
+		It("should bump the pipeline and tasks timeout for a PipelineRunTimeout failure", func() {
 			adapter.release.Status.ManagedPipelineAttempts = []v1alpha1.PipelineAttempt{{
 				PipelineRun:   "default/pr",
 				Status:        v1alpha1.AttemptFailedReason,
@@ -5472,10 +5472,10 @@ var _ = Describe("Release adapter", Ordered, func() {
 			resources := &loader.ProcessingResources{ReleasePlanAdmission: rpa}
 			_, timeouts, appliedMitigation := adapter.computeRetryOverrides(resources)
 			Expect(timeouts.Pipeline.Duration).To(Equal(90 * time.Minute))
-			Expect(timeouts.Tasks.Duration).To(Equal(45 * time.Minute))
+			Expect(timeouts.Tasks.Duration).To(Equal(75 * time.Minute))
 			Expect(appliedMitigation).NotTo(BeNil())
 			Expect(appliedMitigation.PipelinesTimeout).To(Equal("1h30m0s"))
-			Expect(appliedMitigation.TasksTimeout).To(Equal("45m0s"))
+			Expect(appliedMitigation.TasksTimeout).To(Equal("1h15m0s"))
 		})
 
 		It("returns base specs when OOMKill mitigation is not configured", func() {

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -48,6 +48,8 @@ make test-e2e
 |----------|---------|-------------|
 | `RELEASE_SERVICE_CATALOG_URL` | `https://github.com/konflux-ci/release-service-catalog` | Release pipeline catalog repo |
 | `RELEASE_SERVICE_CATALOG_REVISION` | `development` | Catalog git branch/tag |
+| `RELEASE_SERVICE_OPERATOR_URL` | `https://github.com/konflux-ci/release-service.git` | Release Service Operator repo |
+| `RELEASE_SERVICE_OPERATOR_REVISION` | `main` | Git branch/tag |
 | `E2E_APPLICATIONS_NAMESPACE` | *auto-generated* | Override test namespace |
 
 ## Running Tests
@@ -80,8 +82,21 @@ make test-e2e LABEL=negManagedPipelineRunCreationDenied
 | `tenant` | Tenant-only pipeline (no managed namespace) |
 | `release_plan_and_admission` | ReleasePlan ↔ ReleasePlanAdmission matching |
 | `release-neg` | Negative/error scenarios |
+| `negMissingReleasePlan` | Release fails when no matching `ReleasePlan` or `ReleasePlanAdmission` is found |
+| `negBlockReleases` | Release fails when `block-releases: "true"` is set on the `ReleasePlanAdmission` |
 | `negManagedPipelineRunCreationDenied` | Managed release `PipelineRun` create denied by quota; failure is surfaced on `Release` status |
 | `negTenantPipelineInvalidGitRef` | Tenant pipeline with invalid git resolver config (empty URL/revision/pathInRepo); failure is surfaced on `Release` status |
+| `retry-managed` | All managed pipeline retry scenarios |
+| `managed-pipeline-oom-retry` | OOM failure on the managed pipeline is retried with memory limit mitigation |
+| `managed-pipeline-task-timeout-retry` | `TaskRunTimeout` on the managed pipeline is retried with task timeout mitigation |
+| `managed-pipeline-pipeline-timeout-retry` | `PipelineRunTimeout` on the managed pipeline is retried with pipeline/tasks timeout mitigation |
+| `managed-pipeline-error-no-retry` | Generic error failure on the managed pipeline is not retried |
+| `managed-pipeline-max-retries-zero` | OOM failure is not retried when `MaxRetries=0` is set on the RPA, overriding the RSC retry policy |
+| `managed-pipeline-taskrunspecs-oom-retry` | OOM failure on a task whose memory limit is set via RPA `TaskRunSpecs` is retried with the mitigation applied to the overridden limit |
+| `managed-pipeline-retry-final-pipeline-ordering` | Verifies that the final pipeline does not start until all managed pipeline retries have completed in a task-timeout retry scenario |
+| `managed-pipeline-disabled-by-tag-no-retry` | OOM failure is not retried when the RPA mapping data carries a tag matched by the RSC `RetryPolicy.DisableOn.Tags` |
+| `managed-pipeline-retry-exhausted` | Repeated OOM failures exhaust all configured retries (mitigation capped below the OOM threshold), and the Release ultimately fails |
+| `final` | Final pipeline execution and finalizer test |
 
 ## Writing Tests
 

--- a/e2e-tests/pipelines/retry-e2e-managed.yaml
+++ b/e2e-tests/pipelines/retry-e2e-managed.yaml
@@ -1,0 +1,253 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: retry-e2e-managed
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Managed pipeline for retry E2E tests. Reads failMode and failOnTask
+    from releasePlanAdmission.spec.data. error and oom can be triggered
+    on task-01 or task-02. task-timeout is supported on task-01.
+    pipeline-timeout and oom-always is triggered from task-02. 
+    failOnTask defaults to task-01 if not set.
+  params:
+    - name: release
+      type: string
+    - name: releasePlan
+      type: string
+    - name: releasePlanAdmission
+      type: string
+    - name: releaseServiceConfig
+      type: string
+    - name: snapshot
+      type: string
+    - name: enterpriseContractPolicy
+      type: string
+  tasks:
+    - name: collect-data
+      params:
+        - name: releasePlanAdmission
+          value: "$(params.releasePlanAdmission)"
+      taskSpec:
+        params:
+          - name: releasePlanAdmission
+            type: string
+        results:
+          - name: failMode
+            type: string
+          - name: failOnTask
+            type: string
+        steps:
+        # This step collects the failMode and failOnTask values from the RPA
+        # CR and stores them in results for use by downstream tasks. 
+          - name: collect-data
+            image: quay.io/konflux-ci/release-service-utils@sha256:850118bc6eda4ca3f98ef1e53109164f64a0945a6ac0942f908b7e106f50775c
+            computeResources:
+              requests:
+                memory: 64Mi
+                cpu: 50m
+              limits:
+                memory: 64Mi
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              DATA=$(get-resource releasePlanAdmission "$(params.releasePlanAdmission)" |
+                jq '.spec.data // {}')
+
+              FAIL_MODE=$(jq -r '.failMode // "none"' <<<"${DATA}")
+              FAIL_ON_TASK=$(jq -r '.failOnTask // "task-01"' <<<"${DATA}")
+
+              printf '%s' "${FAIL_MODE}" > "$(results.failMode.path)"
+              printf '%s' "${FAIL_ON_TASK}" > "$(results.failOnTask.path)"
+    - name: task-01
+      # Timeout is set to 1 minute to have a TaskRunTimeout error
+      # for the task-timeout failMode. The retry mitigation should 
+      # increase the timeout to allow the task to complete on retry.
+      timeout: "1m"
+      runAfter:
+        - collect-data
+      params:
+        - name: failMode
+          value: "$(tasks.collect-data.results.failMode)"
+        - name: failOnTask
+          value: "$(tasks.collect-data.results.failOnTask)"
+      taskSpec:
+        params:
+          - name: failMode
+            type: string
+          - name: failOnTask
+            type: string
+        steps:
+          - name: task-01-step-01
+            image: quay.io/konflux-ci/release-service-utils@sha256:850118bc6eda4ca3f98ef1e53109164f64a0945a6ac0942f908b7e106f50775c
+            computeResources:
+              requests:
+                memory: 64Mi
+                cpu: 100m
+              limits:
+                memory: 64Mi
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              FAIL_MODE="$(params.failMode)"
+              FAIL_ON_TASK="$(params.failOnTask)"
+
+              # Only inject failures into the selected task.
+              [[ "${FAIL_ON_TASK}" == "task-01" ]] || exit 0
+
+              echo "task-01-step-01: failMode=${FAIL_MODE}"
+
+              case "${FAIL_MODE}" in
+                error)
+                  exit 1
+                  ;;
+                oom)
+                  # Trigger OOM only when the task is still running with the
+                  # original memory limit. After retry mitigation the limit
+                  # should be increased and this path should no longer OOM.
+                  LIMIT="max"
+                  [[ -r /sys/fs/cgroup/memory.max ]] && read -r LIMIT < /sys/fs/cgroup/memory.max
+
+                  THRESHOLD=104857600 # 100 Mi
+
+                  if [[ "${LIMIT}" != "max" ]] && (( LIMIT < THRESHOLD )); then
+                    echo "limit ${LIMIT} < ${THRESHOLD}: triggering OOMKill"
+
+                    X=$(dd if=/dev/zero bs=1M count=150 status=none | tr '\0' 'a')
+                    echo "${#X}"
+                  else
+                    echo "limit ${LIMIT} sufficient"
+                  fi
+                  ;;
+                task-timeout)
+                  # Sleep longer than the task timeout. Which is set to 1 minute.
+                  sleep 90
+                  ;;
+                none)
+                  ;;
+                *)
+                  echo "unknown fail mode: ${FAIL_MODE}" >&2
+                  exit 1
+                  ;;
+              esac
+          - name: task-01-step-02
+            image: quay.io/konflux-ci/release-service-utils@sha256:850118bc6eda4ca3f98ef1e53109164f64a0945a6ac0942f908b7e106f50775c
+            computeResources:
+              requests:
+                memory: 32Mi
+                cpu: 50m
+              limits:
+                memory: 32Mi
+            script: |
+              #!/usr/bin/env bash
+              echo "task-01-step-02: complete"
+    - name: task-02
+      runAfter:
+        - task-01
+      params:
+        - name: failMode
+          value: "$(tasks.collect-data.results.failMode)"
+        - name: failOnTask
+          value: "$(tasks.collect-data.results.failOnTask)"
+      taskSpec:
+        params:
+          - name: failMode
+            type: string
+          - name: failOnTask
+            type: string
+        stepTemplate:
+          image: quay.io/konflux-ci/release-service-utils@sha256:850118bc6eda4ca3f98ef1e53109164f64a0945a6ac0942f908b7e106f50775c
+          # task-02 uses task level computeResources. task-01 defines
+          # computeResources on each step. This allows the retry e2e
+          # tests to verify that resource mitigation are applied
+          # correctly at both the task and step level.
+          computeResources:
+            requests:
+              memory: 64Mi
+              cpu: 100m
+            limits:
+              memory: 64Mi
+        steps:
+          - name: task-02-step-01
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              FAIL_MODE="$(params.failMode)"
+              FAIL_ON_TASK="$(params.failOnTask)"
+
+              # pipeline-timeout always runs from task-02 regardless of failOnTask.
+              if [[ "${FAIL_ON_TASK}" != "task-02" && "${FAIL_MODE}" != "pipeline-timeout" ]]; then
+                echo "task-02: complete"
+                exit 0
+              fi
+
+              echo "task-02-step-01: failMode=${FAIL_MODE}"
+
+              case "${FAIL_MODE}" in
+                pipeline-timeout)
+                  # Sleep past the pipeline level pipeline/tasks timeout. This is used to verify
+                  # that retry mitigation updates both pipeline and tasks timeouts
+                  # and allows the pipelineRun to complete on retry.
+                  echo "task-02-step-01: sleeping 120s"
+                  sleep 120
+                  ;;
+                error)
+                  exit 1
+                  ;;
+                oom)
+                  # Trigger OOM only when the task is still running with the
+                  # original memory limit. After retry mitigation the limit
+                  # should be increased and this path should no longer OOM.
+                  LIMIT="max"
+                  [[ -r /sys/fs/cgroup/memory.max ]] && read -r LIMIT < /sys/fs/cgroup/memory.max
+
+                  THRESHOLD=104857600 # 100 Mi
+
+                  if [[ "${LIMIT}" != "max" ]] && (( LIMIT < THRESHOLD )); then
+                    echo "limit ${LIMIT} < ${THRESHOLD}: triggering OOMKill"
+                    X=$(dd if=/dev/zero bs=1M count=150 status=none | tr '\0' 'a')
+                    echo "${#X}"
+                  else
+                    echo "limit ${LIMIT} sufficient"
+                  fi
+                  ;;
+                oom-always)
+                # Always trigger an OOMKill regardless of the memory limit.
+                # This is used to verify that retry mitigation cannot fix
+                # the failure even after resource requests/limits are increased.
+                
+                X=$(dd if=/dev/zero bs=1M count=2048 status=none | tr '\0' 'a')
+                echo "${#X}"
+                ;;
+                none)
+                  ;;
+                *)
+                  echo "unknown fail mode: ${FAIL_MODE}" >&2
+                  exit 1
+                  ;;
+              esac
+          - name: task-02-step-02
+            script: |
+              #!/usr/bin/env bash
+              echo "task-02-step-02: complete"
+  finally:
+    - name: finalize
+      taskSpec:
+        steps:
+          - name: finalize-step-01
+            image: quay.io/konflux-ci/release-service-utils@sha256:850118bc6eda4ca3f98ef1e53109164f64a0945a6ac0942f908b7e106f50775c
+            computeResources:
+              requests:
+                memory: 32Mi
+                cpu: 50m
+              limits:
+                memory: 32Mi
+            script: |
+              #!/usr/bin/env bash
+              echo "finalize: complete"

--- a/e2e-tests/pipelines/simple-e2e-pipeline.yaml
+++ b/e2e-tests/pipelines/simple-e2e-pipeline.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: simple-e2e-pipeline
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: release
+spec:
+  description: >-
+    Minimal pipeline used for tenant E2E testing. It contains a single task
+    that echo output.
+  params:
+    - name: release
+      type: string
+    - name: releasePlan
+      type: string
+    - name: snapshot
+      type: string
+  tasks:
+    - name: task-01
+      taskSpec:
+        steps:
+          - name: task-01-step-01
+            image: quay.io/konflux-ci/release-service-utils@sha256:850118bc6eda4ca3f98ef1e53109164f64a0945a6ac0942f908b7e106f50775c
+            computeResources:
+              requests:
+                memory: 32Mi
+                cpu: 50m
+              limits:
+                memory: 32Mi
+            script: |
+              #!/usr/bin/env bash
+              echo "simple-e2e-pipeline: complete"

--- a/e2e-tests/pkg/framework/release.go
+++ b/e2e-tests/pkg/framework/release.go
@@ -2,15 +2,20 @@ package framework
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/release-service/loader"
 	releaseMetadata "github.com/konflux-ci/release-service/metadata"
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
@@ -81,6 +86,41 @@ func (r *ReleaseController) GetFirstReleaseInNamespace(namespace string) (*relea
 	return &releaseList.Items[0], nil
 }
 
+// WaitForRelease polls until the Release's "Released" condition shows it has finished.
+// Returns an error if the release failed.
+func (r *ReleaseController) WaitForRelease(release *releaseApi.Release) (*releaseApi.Release, error) {
+	current := release
+	err := wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, constants.ReleasePipelineRunCompletionTimeout, true, func(ctx context.Context) (bool, error) {
+		fetched, getErr := r.GetRelease(release.Name, release.Namespace)
+		if getErr != nil {
+			return false, nil
+		}
+		current = fetched
+
+		condition := meta.FindStatusCondition(current.Status.Conditions, "Released")
+		if condition == nil {
+			return false, nil
+		}
+		if condition.Status == metav1.ConditionTrue {
+			return true, nil
+		}
+		if condition.Status == metav1.ConditionFalse && condition.Reason != "Progressing" {
+			return false, fmt.Errorf("release %s/%s failed: %s", current.Namespace, current.Name, condition.Message)
+		}
+		return false, nil
+	})
+	return current, err
+}
+
+// GetManagedPipelineRetryCount returns the number of retries performed for the managed pipeline
+// (attempts minus the initial run) same as main project code.
+func GetManagedPipelineRetryCount(release *releaseApi.Release) int {
+	if count := len(release.Status.ManagedPipelineAttempts) - 1; count > 0 {
+		return count
+	}
+	return 0
+}
+
 // CreateReleasePipelineRoleBindingForServiceAccount creates a RoleBinding for the release pipeline SA.
 func (r *ReleaseController) CreateReleasePipelineRoleBindingForServiceAccount(namespace string, serviceAccount *corev1.ServiceAccount) (*rbacv1.RoleBinding, error) {
 	rb := &rbacv1.RoleBinding{
@@ -106,6 +146,35 @@ func (r *ReleaseController) CreateReleasePipelineRoleBindingForServiceAccount(na
 		return nil, err
 	}
 	return rb, nil
+}
+
+// =============================================================================
+// ReleaseServiceConfig Operations
+// =============================================================================
+
+// CreateReleaseServiceConfig creates a ReleaseServiceConfig.
+func (r *ReleaseController) CreateReleaseServiceConfig(name, namespace string, retryablePipelines []releaseApi.RetryablePipeline) error {
+	rsc := &releaseApi.ReleaseServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: releaseApi.ReleaseServiceConfigSpec{
+			RetryablePipelines: retryablePipelines,
+		},
+	}
+	return r.kubeClient.Create(context.Background(), rsc)
+}
+
+// DeleteReleaseServiceConfig deletes a ReleaseServiceConfig.
+func (r *ReleaseController) DeleteReleaseServiceConfig(name, namespace string) error {
+	rsc := &releaseApi.ReleaseServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return r.kubeClient.Delete(context.Background(), rsc)
 }
 
 // =============================================================================
@@ -168,7 +237,7 @@ func (r *ReleaseController) DeleteReleasePlan(name, namespace string, wait bool)
 // =============================================================================
 
 // CreateReleasePlanAdmission creates a ReleasePlanAdmission.
-func (r *ReleaseController) CreateReleasePlanAdmission(name, namespace, environment, origin, policy, serviceAccount string, applications []string, blockReleases bool, pipelineRef *tektonutils.PipelineRef, data *runtime.RawExtension) (*releaseApi.ReleasePlanAdmission, error) {
+func (r *ReleaseController) CreateReleasePlanAdmission(name, namespace, environment, origin, policy, serviceAccount string, applications []string, blockReleases bool, pipelineRef *tektonutils.PipelineRef, data *runtime.RawExtension, maxRetries *int, taskRunSpecs []tektonv1.PipelineTaskRunSpec, timeouts *tektonv1.TimeoutFields) (*releaseApi.ReleasePlanAdmission, error) {
 	rpa := &releaseApi.ReleasePlanAdmission{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -184,9 +253,15 @@ func (r *ReleaseController) CreateReleasePlanAdmission(name, namespace, environm
 			Pipeline: &tektonutils.Pipeline{
 				PipelineRef:        *pipelineRef,
 				ServiceAccountName: serviceAccount,
+				MaxRetries:         maxRetries,
+				TaskRunSpecs:       taskRunSpecs,
 			},
 			Data: data,
 		},
+	}
+
+	if timeouts != nil {
+		rpa.Spec.Pipeline.Timeouts = *timeouts
 	}
 
 	err := r.kubeClient.Create(context.Background(), rpa)

--- a/e2e-tests/pkg/framework/tekton.go
+++ b/e2e-tests/pkg/framework/tekton.go
@@ -152,6 +152,25 @@ func (t *TektonController) GetPipelineRunInNamespace(namespace, releaseName, rel
 	return nil, fmt.Errorf("no pipelinerun found for release %s/%s in namespace %s", releaseNamespace, releaseName, namespace)
 }
 
+// WaitForPipelineRunToStart waits until a PipelineRun for the given release appears in managedNamespace.
+func (t *TektonController) WaitForPipelineRunToStart(release *releaseApi.Release, managedNamespace string) error {
+	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, constants.ReleaseCreationTimeout, true, func(ctx context.Context) (done bool, err error) {
+		prs, listErr := t.GetAllPipelineRunsInNamespace(managedNamespace)
+		if listErr != nil {
+			return false, nil
+		}
+		for i := range prs.Items {
+			pr := &prs.Items[i]
+			if pr.Labels != nil &&
+				pr.Labels[metadata.ReleaseNameLabel] == release.GetName() &&
+				pr.Labels[metadata.ReleaseNamespaceLabel] == release.GetNamespace() {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
 // WaitForReleasePipelineToBeFinished waits for a release pipeline to finish.
 // Uses knative apis.ConditionSucceeded for condition checking (same as main project).
 func (t *TektonController) WaitForReleasePipelineToBeFinished(release *releaseApi.Release, managedNamespace string) error {

--- a/e2e-tests/tests/release/service/block_releases_release_plan_admission.go
+++ b/e2e-tests/tests/release/service/block_releases_release_plan_admission.go
@@ -66,7 +66,7 @@ var _ = ginkgo.Describe("Release CR fails when block-releases true in ReleasePla
 				{Name: "revision", Value: releasecommon.RelSvcCatalogRevision},
 				{Name: "pathInRepo", Value: "pipelines/managed/e2e/e2e.yaml"},
 			},
-		}, nil)
+		}, nil, nil, nil, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s with block-releases=true", destinationReleasePlanAdmissionName)
 
 		_, err = fw.AsKubeAdmin.ReleaseController.CreateRelease(releaseName, devNamespace, snapshotName, constants.SourceReleasePlanName)

--- a/e2e-tests/tests/release/service/final_pipeline_finalizer_removed.go
+++ b/e2e-tests/tests/release/service/final_pipeline_finalizer_removed.go
@@ -157,7 +157,7 @@ func setupFinalPipelineFinalizerSuite() {
 				{Name: "revision", Value: pipelineExamplesRev},
 				{Name: "pathInRepo", Value: m.pipelinePath},
 			},
-		}, &runtime.RawExtension{Raw: data})
+		}, &runtime.RawExtension{Raw: data}, nil, nil, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", m.rpaName, err)
 	}
 

--- a/e2e-tests/tests/release/service/managed_pipeline_disabled_by_tag_no_retry.go
+++ b/e2e-tests/tests/release/service/managed_pipeline_disabled_by_tag_no_retry.go
@@ -3,40 +3,37 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	ecp "github.com/conforma/crds/api/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
-
 	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
 	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 )
 
-var _ = ginkgo.Describe("Release service happy path", releasecommon.LabelHappyPath, ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Managed pipeline OOM is not retried when disabled by a production tag", releasecommon.LabelManagedPipelineDisabledByTagNoRetry, ginkgo.Ordered, func() {
 	defer ginkgo.GinkgoRecover()
 
 	var fw *framework.Framework
 	ginkgo.AfterEach(framework.ReportFailure(&fw))
 	var err error
-	var compName string
-	var devNamespace = "happy-path"
-	var managedNamespace = "happy-path-managed"
+	var devNamespace = "retry-tag-disabled"
+	var managedNamespace = "retry-tag-disabled-managed"
 	var _ *appservice.Snapshot
-	var verifyConformaTaskName = "verify-conforma"
-	var releasedImagePushRepo = "quay.io/redhat-appstudio-qe/dcmetromap"
 	var sampleImage = "quay.io/hacbs-release-tests/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
-	var gitSourceURL = constants.GitSourceComponentUrl
 	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
-	var ecPolicyName = "hpath-policy-" + utils.GenerateRandomString(4)
+	var ecPolicyName = "retry-tag-disabled-policy-" + utils.GenerateRandomString(4)
 
 	var releaseCR *releaseApi.Release
 
@@ -48,26 +45,11 @@ var _ = ginkgo.Describe("Release service happy path", releasecommon.LabelHappyPa
 		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s: %v", managedNamespace, err)
 
-		sourceAuthJson := utils.GetEnv("QUAY_TOKEN", "")
-		gomega.Expect(sourceAuthJson).ToNot(gomega.BeEmpty(), "QUAY_TOKEN env var is required (dockerconfigjson format)")
-
-		releaseCatalogTrustedArtifactsQuayAuthJson := utils.GetEnv("RELEASE_CATALOG_TA_QUAY_TOKEN", "")
-		gomega.Expect(releaseCatalogTrustedArtifactsQuayAuthJson).ToNot(gomega.BeEmpty(), "RELEASE_CATALOG_TA_QUAY_TOKEN env var is required (dockerconfigjson format)")
-
-		managedServiceAccount, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, managedNamespace, releasecommon.ManagednamespaceSecret, nil)
+		managedServiceAccount, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, managedNamespace, nil, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", constants.ReleasePipelineServiceAccountDefault, managedNamespace, err)
 
 		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create rolebinding for service account: %v", err)
-
-		_, err = fw.AsKubeAdmin.CommonController.CreateRegistryAuthSecret(constants.RedhatAppstudioUserSecret, managedNamespace, sourceAuthJson)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to create secret %s: %v", constants.RedhatAppstudioUserSecret, err)
-
-		_, err = fw.AsKubeAdmin.CommonController.CreateRegistryAuthSecret(constants.ReleaseCatalogTAQuaySecret, managedNamespace, releaseCatalogTrustedArtifactsQuayAuthJson)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to create secret %s: %v", constants.ReleaseCatalogTAQuaySecret, err)
-
-		err = fw.AsKubeAdmin.CommonController.LinkSecretToServiceAccount(managedNamespace, constants.RedhatAppstudioUserSecret, constants.ReleasePipelineServiceAccountDefault, true)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "failed to link secret to service account: %v", err)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding: %v", err)
 
 		releasePublicKeyDecoded := []byte("-----BEGIN PUBLIC KEY-----\n" +
 			"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEocSG/SnE0vQ20wRfPltlXrY4Ib9B\n" +
@@ -94,6 +76,43 @@ var _ = ginkgo.Describe("Release service happy path", releasecommon.LabelHappyPa
 		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)
 
+		// Delete any existing ReleaseServiceConfig and create a new one with the desired RetryablePipeline configuration.
+		_ = fw.AsKubeAdmin.ReleaseController.DeleteReleaseServiceConfig(releaseApi.ReleaseServiceConfigResourceName, "release-service")
+		err = fw.AsKubeAdmin.ReleaseController.CreateReleaseServiceConfig(
+			releaseApi.ReleaseServiceConfigResourceName, "release-service", []releaseApi.RetryablePipeline{
+				{
+					Url:        releasecommon.RelSvcOperatorURL,
+					Revision:   releasecommon.RelSvcOperatorRevision,
+					PathInRepo: "e2e-tests/pipelines/retry-e2e-managed.yaml",
+					RetryPolicy: releaseApi.RetryPolicy{
+						MaxRetries: 3,
+						DisableOn: &releaseApi.DisableConditions{
+							Tags: []string{"production"},
+						},
+						Mitigations: &releaseApi.Mitigations{
+							OOMKill: &releaseApi.MemoryMitigation{
+								Multiplier: "2.0",
+								MaxComputeResources: &corev1.ResourceRequirements{
+									Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+								},
+							},
+							Timeout: &releaseApi.TimeoutMitigation{
+								Task: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+								},
+								Pipeline: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 20 * time.Minute},
+								},
+							},
+						},
+					},
+				},
+			})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleaseServiceConfig: %v", err)
+
 		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
 
@@ -101,43 +120,40 @@ var _ = ginkgo.Describe("Release service happy path", releasecommon.LabelHappyPa
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
 
 		data, err := json.Marshal(map[string]interface{}{
+			"failMode":   "oom",
+			"failOnTask": "task-02",
 			"mapping": map[string]interface{}{
 				"components": []map[string]interface{}{
 					{
-						"component":  compName,
-						"repository": releasedImagePushRepo,
+						"name": constants.ComponentName,
+						"repositories": []map[string]interface{}{
+							{
+								"url":  "quay.io/redhat/example-component",
+								"tags": []string{"production"},
+							},
+						},
 					},
 				},
 			},
 		})
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RPA data: %v", err)
 
+		// The RPA overrides MaxRetries value higher than the RSC default 3 to prove
+		// that DisableOn.Tags still wins even when retries are increased.
+		maxRetries := 4
 		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
 			Resolver: "git",
 			Params: []tektonutils.Param{
-				{Name: "url", Value: releasecommon.RelSvcCatalogURL},
-				{Name: "revision", Value: releasecommon.RelSvcCatalogRevision},
-				{Name: "pathInRepo", Value: "pipelines/managed/e2e/e2e.yaml"},
+				{Name: "url", Value: releasecommon.RelSvcOperatorURL},
+				{Name: "revision", Value: releasecommon.RelSvcOperatorRevision},
+				{Name: "pathInRepo", Value: "e2e-tests/pipelines/retry-e2e-managed.yaml"},
 			},
 		}, &runtime.RawExtension{
 			Raw: data,
-		}, nil, nil, nil)
+		}, &maxRetries, nil, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", constants.TargetReleasePlanAdmissionName, err)
 
-		_, err = fw.AsKubeAdmin.CommonController.CreateRole("role-release-service-account", managedNamespace, map[string][]string{
-			"apiGroupsList": {""},
-			"roleResources": {"secrets"},
-			"roleVerbs":     {"get", "list", "watch"},
-		})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Role: %v", err)
-
-		_, err = fw.AsKubeAdmin.CommonController.CreateRoleBinding("role-release-service-account-binding", managedNamespace, "ServiceAccount", constants.ReleasePipelineServiceAccountDefault, managedNamespace, "Role", "role-release-service-account", "rbac.authorization.k8s.io")
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding: %v", err)
-
-		_, err = fw.AsKubeAdmin.TektonController.CreatePVCInAccessMode(constants.ReleasePvcName, managedNamespace, corev1.ReadWriteOnce)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create PVC %s: %v", constants.ReleasePvcName, err)
-
-		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, gitSourceURL, gitSourceRevision, "", "", "", "")
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, constants.GitSourceComponentUrl, gitSourceRevision, "", "", "", "")
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
 	})
 
@@ -157,38 +173,21 @@ var _ = ginkgo.Describe("Release service happy path", releasecommon.LabelHappyPa
 			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("verifies that Release PipelineRun is triggered", func() {
-			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForReleasePipelineToBeFinished(releaseCR, managedNamespace)).To(gomega.Succeed(), "pipelinerun for release %s/%s failed", releaseCR.GetNamespace(), releaseCR.GetName())
+		ginkgo.It("verifies that a managed PipelineRun is triggered", func() {
+			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForPipelineRunToStart(releaseCR, managedNamespace)).To(gomega.Succeed())
 		})
 
-		ginkgo.It("verifies that Enterprise Contract Task has succeeded in the Release PipelineRun", func() {
-			gomega.Eventually(func() error {
-				pr, err := fw.AsKubeAdmin.TektonController.GetPipelineRunInNamespace(managedNamespace, releaseCR.GetName(), releaseCR.GetNamespace())
-				if err != nil {
-					return fmt.Errorf("failed to get PipelineRun: %w", err)
-				}
-				ecTaskRunStatus, err := fw.AsKubeAdmin.TektonController.GetTaskRunStatus(fw.AsKubeAdmin.CommonController.KubeRest(), pr, verifyConformaTaskName)
-				if err != nil {
-					return fmt.Errorf("failed to get TaskRun status for %s: %w", verifyConformaTaskName, err)
-				}
-				if !framework.DidTaskSucceed(ecTaskRunStatus) {
-					return fmt.Errorf("task %s has not succeeded yet", verifyConformaTaskName)
-				}
-				return nil
-			}, constants.ReleasePipelineRunCompletionTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		ginkgo.It("verifies the Release is marked as failed", func() {
+			releaseCR, err = fw.AsKubeAdmin.ReleaseController.WaitForRelease(releaseCR)
+			gomega.Expect(err).To(gomega.HaveOccurred(), "expected release %s/%s to fail", releaseCR.GetNamespace(), releaseCR.GetName())
 		})
 
-		ginkgo.It("verifies that a Release is marked as succeeded.", func() {
-			gomega.Eventually(func() error {
-				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
-				if err != nil {
-					return fmt.Errorf("failed to get Release: %w", err)
-				}
-				if !releaseCR.IsReleased() {
-					return fmt.Errorf("release %s is not marked as released yet", releaseCR.Name)
-				}
-				return nil
-			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		ginkgo.It("verifies the Release failed with a single OOM attempt and no retries", func() {
+			gomega.Expect(framework.GetManagedPipelineRetryCount(releaseCR)).To(gomega.Equal(0), "expected no retries when disabled by the production tag, even with the RPA MaxRetries override set to 4")
+
+			attempts := releaseCR.Status.ManagedPipelineAttempts
+			gomega.Expect(attempts).NotTo(gomega.BeEmpty(), "expected a single managed pipeline attempt to be present")
+			gomega.Expect(attempts[0].FailureReason).To(gomega.Equal("OOMKill"), "expected OOMKill failure reason, got %s", attempts[0].FailureReason)
 		})
 	})
 })

--- a/e2e-tests/tests/release/service/managed_pipeline_error_no_retry.go
+++ b/e2e-tests/tests/release/service/managed_pipeline_error_no_retry.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	ecp "github.com/conforma/crds/api/v1alpha1"
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+)
+
+var _ = ginkgo.Describe("Managed pipeline is not retried on a generic error", releasecommon.LabelManagedPipelineErrorNoRetry, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+	var err error
+	var devNamespace = "retry-error"
+	var managedNamespace = "retry-error-managed"
+	var _ *appservice.Snapshot
+	var sampleImage = "quay.io/hacbs-release-tests/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+	var ecPolicyName = "retry-error-policy-" + utils.GenerateRandomString(4)
+
+	var releaseCR *releaseApi.Release
+
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework: %v", err)
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s: %v", managedNamespace, err)
+
+		managedServiceAccount, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, managedNamespace, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", constants.ReleasePipelineServiceAccountDefault, managedNamespace, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding: %v", err)
+
+		releasePublicKeyDecoded := []byte("-----BEGIN PUBLIC KEY-----\n" +
+			"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEocSG/SnE0vQ20wRfPltlXrY4Ib9B\n" +
+			"CRnFUCg/fndZsXdz0IX5sfzIyspizaTbu4rapV85KirmSBU6XUaLY347xg==\n" +
+			"-----END PUBLIC KEY-----")
+		err = fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(releasePublicKeyDecoded, constants.PublicSecretNameAuth, managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create signing secret %s: %v", constants.PublicSecretNameAuth, err)
+
+		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		gomega.Expect(defaultEcPolicy.Spec.Sources).ToNot(gomega.BeEmpty(), "default EC policy has no sources")
+
+		source := defaultEcPolicy.Spec.Sources[0]
+		source.Config = &ecp.SourceConfig{
+			Include: []string{"@slsa3"},
+			Exclude: []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+		}
+
+		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
+			Description: "Red Hat's enterprise requirements",
+			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, constants.PublicSecretNameAuth),
+			Sources:     []ecp.Source{source},
+		}
+		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)
+
+		// Delete any existing ReleaseServiceConfig and create a new one with the desired RetryablePipeline configuration.
+		_ = fw.AsKubeAdmin.ReleaseController.DeleteReleaseServiceConfig(releaseApi.ReleaseServiceConfigResourceName, "release-service")
+		err = fw.AsKubeAdmin.ReleaseController.CreateReleaseServiceConfig(
+			releaseApi.ReleaseServiceConfigResourceName, "release-service", []releaseApi.RetryablePipeline{
+				{
+					Url:        releasecommon.RelSvcOperatorURL,
+					Revision:   releasecommon.RelSvcOperatorRevision,
+					PathInRepo: "e2e-tests/pipelines/retry-e2e-managed.yaml",
+					RetryPolicy: releaseApi.RetryPolicy{
+						MaxRetries: 3,
+						Mitigations: &releaseApi.Mitigations{
+							OOMKill: &releaseApi.MemoryMitigation{
+								Multiplier: "2.0",
+								MaxComputeResources: &corev1.ResourceRequirements{
+									Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+								},
+							},
+							Timeout: &releaseApi.TimeoutMitigation{
+								Task: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+								},
+								Pipeline: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 20 * time.Minute},
+								},
+							},
+						},
+					},
+				},
+			})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleaseServiceConfig: %v", err)
+
+		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
+
+		data, err := json.Marshal(map[string]interface{}{
+			"failMode":   "error",
+			"failOnTask": "task-01",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RPA data: %v", err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
+			Resolver: "git",
+			Params: []tektonutils.Param{
+				{Name: "url", Value: releasecommon.RelSvcOperatorURL},
+				{Name: "revision", Value: releasecommon.RelSvcOperatorRevision},
+				{Name: "pathInRepo", Value: "e2e-tests/pipelines/retry-e2e-managed.yaml"},
+			},
+		}, &runtime.RawExtension{
+			Raw: data,
+		}, nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", constants.TargetReleasePlanAdmissionName, err)
+
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, constants.GitSourceComponentUrl, gitSourceRevision, "", "", "", "")
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("Post-release verification", func() {
+
+		ginkgo.It("verifies that a Release CR should have been created in the dev namespace", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				return err
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that a managed PipelineRun is triggered", func() {
+			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForPipelineRunToStart(releaseCR, managedNamespace)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies the Release is marked as failed", func() {
+			releaseCR, err = fw.AsKubeAdmin.ReleaseController.WaitForRelease(releaseCR)
+			gomega.Expect(err).To(gomega.HaveOccurred(), "expected release %s/%s to fail", releaseCR.GetNamespace(), releaseCR.GetName())
+		})
+
+		ginkgo.It("verifies the Release is marked as failed with a single error attempt and no retries", func() {
+			gomega.Expect(framework.GetManagedPipelineRetryCount(releaseCR)).To(gomega.Equal(0), "expected no retries for a generic error")
+
+			attempts := releaseCR.Status.ManagedPipelineAttempts
+			gomega.Expect(attempts).NotTo(gomega.BeEmpty(), "expected a single managed pipeline attempt to be present")
+			gomega.Expect(attempts[0].FailureReason).To(gomega.Equal("Error"), "expected error failure reason, got %s", attempts[0].FailureReason)
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/managed_pipeline_max_retries_zero.go
+++ b/e2e-tests/tests/release/service/managed_pipeline_max_retries_zero.go
@@ -1,0 +1,175 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	ecp "github.com/conforma/crds/api/v1alpha1"
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+)
+
+var _ = ginkgo.Describe("Managed pipeline OOM is not retried when RPA MaxRetries is zero", releasecommon.LabelManagedPipelineMaxRetriesZero, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+	var err error
+	var devNamespace = "retry-maxzero"
+	var managedNamespace = "retry-maxzero-managed"
+	var _ *appservice.Snapshot
+	var sampleImage = "quay.io/hacbs-release-tests/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+	var ecPolicyName = "retry-maxzero-policy-" + utils.GenerateRandomString(4)
+
+	var releaseCR *releaseApi.Release
+
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework: %v", err)
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s: %v", managedNamespace, err)
+
+		managedServiceAccount, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, managedNamespace, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", constants.ReleasePipelineServiceAccountDefault, managedNamespace, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding: %v", err)
+
+		releasePublicKeyDecoded := []byte("-----BEGIN PUBLIC KEY-----\n" +
+			"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEocSG/SnE0vQ20wRfPltlXrY4Ib9B\n" +
+			"CRnFUCg/fndZsXdz0IX5sfzIyspizaTbu4rapV85KirmSBU6XUaLY347xg==\n" +
+			"-----END PUBLIC KEY-----")
+		err = fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(releasePublicKeyDecoded, constants.PublicSecretNameAuth, managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create signing secret %s: %v", constants.PublicSecretNameAuth, err)
+
+		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		gomega.Expect(defaultEcPolicy.Spec.Sources).ToNot(gomega.BeEmpty(), "default EC policy has no sources")
+
+		source := defaultEcPolicy.Spec.Sources[0]
+		source.Config = &ecp.SourceConfig{
+			Include: []string{"@slsa3"},
+			Exclude: []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+		}
+
+		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
+			Description: "Red Hat's enterprise requirements",
+			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, constants.PublicSecretNameAuth),
+			Sources:     []ecp.Source{source},
+		}
+		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)
+
+		// Delete any existing ReleaseServiceConfig and create a new one with the desired RetryablePipeline configuration.
+		_ = fw.AsKubeAdmin.ReleaseController.DeleteReleaseServiceConfig(releaseApi.ReleaseServiceConfigResourceName, "release-service")
+		err = fw.AsKubeAdmin.ReleaseController.CreateReleaseServiceConfig(
+			releaseApi.ReleaseServiceConfigResourceName, "release-service", []releaseApi.RetryablePipeline{
+				{
+					Url:        releasecommon.RelSvcOperatorURL,
+					Revision:   releasecommon.RelSvcOperatorRevision,
+					PathInRepo: "e2e-tests/pipelines/retry-e2e-managed.yaml",
+					RetryPolicy: releaseApi.RetryPolicy{
+						MaxRetries: 3,
+						Mitigations: &releaseApi.Mitigations{
+							OOMKill: &releaseApi.MemoryMitigation{
+								Multiplier: "2.0",
+								MaxComputeResources: &corev1.ResourceRequirements{
+									Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+								},
+							},
+							Timeout: &releaseApi.TimeoutMitigation{
+								Task: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+								},
+								Pipeline: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 20 * time.Minute},
+								},
+							},
+						},
+					},
+				},
+			})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleaseServiceConfig: %v", err)
+
+		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
+
+		data, err := json.Marshal(map[string]interface{}{
+			"failMode":   "oom",
+			"failOnTask": "task-01",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RPA data: %v", err)
+
+		maxRetries := 0
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
+			Resolver: "git",
+			Params: []tektonutils.Param{
+				{Name: "url", Value: releasecommon.RelSvcOperatorURL},
+				{Name: "revision", Value: releasecommon.RelSvcOperatorRevision},
+				{Name: "pathInRepo", Value: "e2e-tests/pipelines/retry-e2e-managed.yaml"},
+			},
+		}, &runtime.RawExtension{
+			Raw: data,
+		}, &maxRetries, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", constants.TargetReleasePlanAdmissionName, err)
+
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, constants.GitSourceComponentUrl, gitSourceRevision, "", "", "", "")
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("Post-release verification", func() {
+
+		ginkgo.It("verifies that a Release CR should have been created in the dev namespace", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				return err
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that a managed PipelineRun is triggered", func() {
+			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForPipelineRunToStart(releaseCR, managedNamespace)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies the Release is marked as failed", func() {
+			releaseCR, err = fw.AsKubeAdmin.ReleaseController.WaitForRelease(releaseCR)
+			gomega.Expect(err).To(gomega.HaveOccurred(), "expected release %s/%s to fail", releaseCR.GetNamespace(), releaseCR.GetName())
+		})
+
+		ginkgo.It("verifies the Release failed with an OOM attempt and with no retries", func() {
+			gomega.Expect(framework.GetManagedPipelineRetryCount(releaseCR)).To(gomega.Equal(0), "expected no retries as MaxRetries=0 on RPA overrides the RSC")
+
+			attempts := releaseCR.Status.ManagedPipelineAttempts
+			gomega.Expect(attempts).NotTo(gomega.BeEmpty(), "expected a single managed pipeline attempt to be present")
+			gomega.Expect(attempts[0].FailureReason).To(gomega.Equal("OOMKill"), "expected OOMKill failure reason, got %s", attempts[0].FailureReason)
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/managed_pipeline_oom_retry.go
+++ b/e2e-tests/tests/release/service/managed_pipeline_oom_retry.go
@@ -1,0 +1,177 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	ecp "github.com/conforma/crds/api/v1alpha1"
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+)
+
+var _ = ginkgo.Describe("Managed pipeline is retried when OOM failure is encountered with memory mitigation", releasecommon.LabelManagedPipelineOOMRetry, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+	var err error
+	var devNamespace = "retry-oom"
+	var managedNamespace = "retry-oom-managed"
+	var _ *appservice.Snapshot
+	var sampleImage = "quay.io/hacbs-release-tests/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+	var ecPolicyName = "retry-oom-policy-" + utils.GenerateRandomString(4)
+
+	var releaseCR *releaseApi.Release
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework: %v", err)
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s: %v", managedNamespace, err)
+
+		managedServiceAccount, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, managedNamespace, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", constants.ReleasePipelineServiceAccountDefault, managedNamespace, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding: %v", err)
+
+		releasePublicKeyDecoded := []byte("-----BEGIN PUBLIC KEY-----\n" +
+			"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEocSG/SnE0vQ20wRfPltlXrY4Ib9B\n" +
+			"CRnFUCg/fndZsXdz0IX5sfzIyspizaTbu4rapV85KirmSBU6XUaLY347xg==\n" +
+			"-----END PUBLIC KEY-----")
+		err = fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(releasePublicKeyDecoded, constants.PublicSecretNameAuth, managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create signing secret %s: %v", constants.PublicSecretNameAuth, err)
+
+		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		gomega.Expect(defaultEcPolicy.Spec.Sources).ToNot(gomega.BeEmpty(), "default EC policy has no sources")
+
+		source := defaultEcPolicy.Spec.Sources[0]
+		source.Config = &ecp.SourceConfig{
+			Include: []string{"@slsa3"},
+			Exclude: []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+		}
+
+		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
+			Description: "Red Hat's enterprise requirements",
+			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, constants.PublicSecretNameAuth),
+			Sources:     []ecp.Source{source},
+		}
+		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)
+
+		// Delete any existing ReleaseServiceConfig and create a new one with the desired RetryablePipeline configuration.
+		_ = fw.AsKubeAdmin.ReleaseController.DeleteReleaseServiceConfig(releaseApi.ReleaseServiceConfigResourceName, "release-service")
+		err = fw.AsKubeAdmin.ReleaseController.CreateReleaseServiceConfig(
+			releaseApi.ReleaseServiceConfigResourceName, "release-service", []releaseApi.RetryablePipeline{
+				{
+					Url:        releasecommon.RelSvcOperatorURL,
+					Revision:   releasecommon.RelSvcOperatorRevision,
+					PathInRepo: "e2e-tests/pipelines/retry-e2e-managed.yaml",
+					RetryPolicy: releaseApi.RetryPolicy{
+						MaxRetries: 3,
+						Mitigations: &releaseApi.Mitigations{
+							OOMKill: &releaseApi.MemoryMitigation{
+								Multiplier: "2.0",
+								MaxComputeResources: &corev1.ResourceRequirements{
+									Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+								},
+							},
+							Timeout: &releaseApi.TimeoutMitigation{
+								Task: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+								},
+								Pipeline: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 20 * time.Minute},
+								},
+							},
+						},
+					},
+				},
+			})
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleaseServiceConfig: %v", err)
+
+		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
+
+		data, err := json.Marshal(map[string]interface{}{
+			"failMode":   "oom",
+			"failOnTask": "task-01",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RPA data: %v", err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
+			Resolver: "git",
+			Params: []tektonutils.Param{
+				{Name: "url", Value: releasecommon.RelSvcOperatorURL},
+				{Name: "revision", Value: releasecommon.RelSvcOperatorRevision},
+				{Name: "pathInRepo", Value: "e2e-tests/pipelines/retry-e2e-managed.yaml"},
+			},
+		}, &runtime.RawExtension{
+			Raw: data,
+		}, nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", constants.TargetReleasePlanAdmissionName, err)
+
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, constants.GitSourceComponentUrl, gitSourceRevision, "", "", "", "")
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("Post-release verification", func() {
+
+		ginkgo.It("verifies that a Release CR should have been created in the dev namespace", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				return err
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that a managed PipelineRun is triggered", func() {
+			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForPipelineRunToStart(releaseCR, managedNamespace)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies the Release is marked as succeeded", func() {
+			releaseCR, err = fw.AsKubeAdmin.ReleaseController.WaitForRelease(releaseCR)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "expected release %s/%s to succeed", releaseCR.GetNamespace(), releaseCR.GetName())
+		})
+
+		ginkgo.It("verifies the Release is marked as succeeded with a memory mitigation applied", func() {
+			gomega.Expect(framework.GetManagedPipelineRetryCount(releaseCR)).To(gomega.Equal(1), "expected exactly one retry")
+
+			attempts := releaseCR.Status.ManagedPipelineAttempts
+			gomega.Expect(attempts[0].FailureReason).To(gomega.Equal("OOMKill"), "expected OOMKill failure reason, got %s", attempts[0].FailureReason)
+
+			lastAttempt := attempts[len(attempts)-1]
+			gomega.Expect(lastAttempt.Mitigation).NotTo(gomega.BeNil(), "expected memory mitigation to be recorded")
+			gomega.Expect(lastAttempt.Mitigation.MemoryLimit).NotTo(gomega.BeEmpty(), "expected MemoryLimit to be set by mitigation")
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/managed_pipeline_pipeline_timeout_retry.go
+++ b/e2e-tests/tests/release/service/managed_pipeline_pipeline_timeout_retry.go
@@ -1,0 +1,190 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	ecp "github.com/conforma/crds/api/v1alpha1"
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+)
+
+var _ = ginkgo.Describe("Managed pipeline is retried when pipeline and tasks timeout is encountered with timeout mitigation", releasecommon.LabelManagedPipelinePipelineTimeoutRetry, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+	var err error
+	var devNamespace = "retry-pipeline-timeout"
+	var managedNamespace = "retry-pipeline-timeout-managed"
+	var _ *appservice.Snapshot
+	var sampleImage = "quay.io/hacbs-release-tests/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+	var ecPolicyName = "retry-pl-timeout-policy-" + utils.GenerateRandomString(4)
+
+	var releaseCR *releaseApi.Release
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework: %v", err)
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s: %v", managedNamespace, err)
+
+		managedServiceAccount, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, managedNamespace, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", constants.ReleasePipelineServiceAccountDefault, managedNamespace, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding: %v", err)
+
+		releasePublicKeyDecoded := []byte("-----BEGIN PUBLIC KEY-----\n" +
+			"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEocSG/SnE0vQ20wRfPltlXrY4Ib9B\n" +
+			"CRnFUCg/fndZsXdz0IX5sfzIyspizaTbu4rapV85KirmSBU6XUaLY347xg==\n" +
+			"-----END PUBLIC KEY-----")
+		err = fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(releasePublicKeyDecoded, constants.PublicSecretNameAuth, managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create signing secret %s: %v", constants.PublicSecretNameAuth, err)
+
+		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		gomega.Expect(defaultEcPolicy.Spec.Sources).ToNot(gomega.BeEmpty(), "default EC policy has no sources")
+
+		source := defaultEcPolicy.Spec.Sources[0]
+		source.Config = &ecp.SourceConfig{
+			Include: []string{"@slsa3"},
+			Exclude: []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+		}
+
+		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
+			Description: "Red Hat's enterprise requirements",
+			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, constants.PublicSecretNameAuth),
+			Sources:     []ecp.Source{source},
+		}
+		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)
+
+		// Delete any existing ReleaseServiceConfig and create a new one with the desired RetryablePipeline configuration.
+		_ = fw.AsKubeAdmin.ReleaseController.DeleteReleaseServiceConfig(releaseApi.ReleaseServiceConfigResourceName, "release-service")
+		err = fw.AsKubeAdmin.ReleaseController.CreateReleaseServiceConfig(
+			releaseApi.ReleaseServiceConfigResourceName, "release-service", []releaseApi.RetryablePipeline{
+				{
+					Url:        releasecommon.RelSvcOperatorURL,
+					Revision:   releasecommon.RelSvcOperatorRevision,
+					PathInRepo: "e2e-tests/pipelines/retry-e2e-managed.yaml",
+					RetryPolicy: releaseApi.RetryPolicy{
+						MaxRetries: 3,
+						Mitigations: &releaseApi.Mitigations{
+							OOMKill: &releaseApi.MemoryMitigation{
+								Multiplier: "2.0",
+								MaxComputeResources: &corev1.ResourceRequirements{
+									Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+								},
+							},
+							Timeout: &releaseApi.TimeoutMitigation{
+								Task: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+								},
+								Pipeline: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 20 * time.Minute},
+								},
+							},
+						},
+					},
+				},
+			})
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleaseServiceConfig: %v", err)
+
+		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
+
+		data, err := json.Marshal(map[string]interface{}{
+			"failMode":   "pipeline-timeout",
+			"failOnTask": "task-02",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RPA data: %v", err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, constants.ReleasePipelineServiceAccountDefault,
+			[]string{constants.ApplicationNameDefault},
+			false,
+			&tektonutils.PipelineRef{
+				Resolver: "git",
+				Params: []tektonutils.Param{
+					{Name: "url", Value: releasecommon.RelSvcOperatorURL},
+					{Name: "revision", Value: releasecommon.RelSvcOperatorRevision},
+					{Name: "pathInRepo", Value: "e2e-tests/pipelines/retry-e2e-managed.yaml"},
+				},
+			},
+			&runtime.RawExtension{
+				Raw: data,
+			},
+			nil,
+			nil,
+			&tektonv1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: 3 * time.Minute},
+				Tasks:    &metav1.Duration{Duration: 90 * time.Second},
+			},
+		)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", constants.TargetReleasePlanAdmissionName, err)
+
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, constants.GitSourceComponentUrl, gitSourceRevision, "", "", "", "")
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("Post-release verification", func() {
+
+		ginkgo.It("verifies that a Release CR should have been created in the dev namespace", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				return err
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that a managed PipelineRun is triggered", func() {
+			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForPipelineRunToStart(releaseCR, managedNamespace)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies the Release is marked as succeeded", func() {
+			releaseCR, err = fw.AsKubeAdmin.ReleaseController.WaitForRelease(releaseCR)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "expected release %s/%s to succeed", releaseCR.GetNamespace(), releaseCR.GetName())
+		})
+
+		ginkgo.It("verifies the Release is marked as succeeded with a pipeline timeout mitigation applied", func() {
+			gomega.Expect(framework.GetManagedPipelineRetryCount(releaseCR)).To(gomega.Equal(1), "expected exactly one retry")
+
+			attempts := releaseCR.Status.ManagedPipelineAttempts
+			gomega.Expect(attempts[0].FailureReason).To(gomega.Equal("PipelineRunTimeout"), "expected PipelineRunTimeout failure reason, got %s", attempts[0].FailureReason)
+
+			lastAttempt := attempts[len(attempts)-1]
+			gomega.Expect(lastAttempt.Mitigation).NotTo(gomega.BeNil(), "expected pipeline timeout mitigation to be present")
+			gomega.Expect(lastAttempt.Mitigation.PipelinesTimeout).NotTo(gomega.BeEmpty(), "expected PipelineTimeout to be set by mitigation")
+			gomega.Expect(lastAttempt.Mitigation.TasksTimeout).NotTo(gomega.BeEmpty(), "expected TasksTimeout to be set by mitigation")
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/managed_pipeline_retry_exhausted.go
+++ b/e2e-tests/tests/release/service/managed_pipeline_retry_exhausted.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	ecp "github.com/conforma/crds/api/v1alpha1"
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+)
+
+var _ = ginkgo.Describe("Managed pipeline fails once retries are exhausted after repeated OOM failures", releasecommon.LabelManagedPipelineRetryExhausted, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+	var err error
+	var devNamespace = "retry-exhausted"
+	var managedNamespace = "retry-exhausted-managed"
+	var _ *appservice.Snapshot
+	var sampleImage = "quay.io/hacbs-release-tests/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+	var ecPolicyName = "retry-exhausted-policy-" + utils.GenerateRandomString(4)
+
+	var releaseCR *releaseApi.Release
+
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework: %v", err)
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s: %v", managedNamespace, err)
+
+		managedServiceAccount, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, managedNamespace, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", constants.ReleasePipelineServiceAccountDefault, managedNamespace, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding: %v", err)
+
+		releasePublicKeyDecoded := []byte("-----BEGIN PUBLIC KEY-----\n" +
+			"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEocSG/SnE0vQ20wRfPltlXrY4Ib9B\n" +
+			"CRnFUCg/fndZsXdz0IX5sfzIyspizaTbu4rapV85KirmSBU6XUaLY347xg==\n" +
+			"-----END PUBLIC KEY-----")
+		err = fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(releasePublicKeyDecoded, constants.PublicSecretNameAuth, managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create signing secret %s: %v", constants.PublicSecretNameAuth, err)
+
+		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		gomega.Expect(defaultEcPolicy.Spec.Sources).ToNot(gomega.BeEmpty(), "default EC policy has no sources")
+
+		source := defaultEcPolicy.Spec.Sources[0]
+		source.Config = &ecp.SourceConfig{
+			Include: []string{"@slsa3"},
+			Exclude: []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+		}
+
+		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
+			Description: "Red Hat's enterprise requirements",
+			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, constants.PublicSecretNameAuth),
+			Sources:     []ecp.Source{source},
+		}
+		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)
+
+		_ = fw.AsKubeAdmin.ReleaseController.DeleteReleaseServiceConfig(releaseApi.ReleaseServiceConfigResourceName, "release-service")
+		err = fw.AsKubeAdmin.ReleaseController.CreateReleaseServiceConfig(
+			releaseApi.ReleaseServiceConfigResourceName, "release-service", []releaseApi.RetryablePipeline{
+				{
+					Url:        releasecommon.RelSvcOperatorURL,
+					Revision:   releasecommon.RelSvcOperatorRevision,
+					PathInRepo: "e2e-tests/pipelines/retry-e2e-managed.yaml",
+					RetryPolicy: releaseApi.RetryPolicy{
+						MaxRetries: 2,
+						Mitigations: &releaseApi.Mitigations{
+							OOMKill: &releaseApi.MemoryMitigation{
+								Multiplier: "2.0",
+								MaxComputeResources: &corev1.ResourceRequirements{
+									Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("80Mi")},
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("80Mi")},
+								},
+							},
+							Timeout: &releaseApi.TimeoutMitigation{
+								Task: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+								},
+								Pipeline: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 20 * time.Minute},
+								},
+							},
+						},
+					},
+				},
+			})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleaseServiceConfig: %v", err)
+
+		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
+
+		data, err := json.Marshal(map[string]interface{}{
+			"failMode":   "oom-always",
+			"failOnTask": "task-02",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RPA data: %v", err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
+			Resolver: "git",
+			Params: []tektonutils.Param{
+				{Name: "url", Value: releasecommon.RelSvcOperatorURL},
+				{Name: "revision", Value: releasecommon.RelSvcOperatorRevision},
+				{Name: "pathInRepo", Value: "e2e-tests/pipelines/retry-e2e-managed.yaml"},
+			},
+		}, &runtime.RawExtension{
+			Raw: data,
+		}, nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", constants.TargetReleasePlanAdmissionName, err)
+
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, constants.GitSourceComponentUrl, gitSourceRevision, "", "", "", "")
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("Post-release verification", func() {
+
+		ginkgo.It("verifies that a Release CR should have been created in the dev namespace", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				return err
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that a managed PipelineRun is triggered", func() {
+			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForPipelineRunToStart(releaseCR, managedNamespace)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies the Release is marked as failed", func() {
+			releaseCR, err = fw.AsKubeAdmin.ReleaseController.WaitForRelease(releaseCR)
+			gomega.Expect(err).To(gomega.HaveOccurred(), "expected release %s/%s to fail", releaseCR.GetNamespace(), releaseCR.GetName())
+		})
+
+		ginkgo.It("verifies the Release failed with every retry exhausted on repeated OOM failures", func() {
+			gomega.Expect(framework.GetManagedPipelineRetryCount(releaseCR)).To(gomega.Equal(2), "expected retries to be exhausted at MaxRetries")
+
+			attempts := releaseCR.Status.ManagedPipelineAttempts
+			for i, attempt := range attempts {
+				gomega.Expect(attempt.FailureReason).To(gomega.Equal("OOMKill"), "expected attempt %d to fail with OOMKill, got %s", i, attempt.FailureReason)
+			}
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/managed_pipeline_retry_final_pipeline_ordering.go
+++ b/e2e-tests/tests/release/service/managed_pipeline_retry_final_pipeline_ordering.go
@@ -1,0 +1,208 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	ecp "github.com/conforma/crds/api/v1alpha1"
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+)
+
+var _ = ginkgo.Describe("Managed pipeline retry blocks final pipeline until all attempts complete", releasecommon.LabelManagedPipelineRetryFinalPipelineOrdering, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+	var err error
+	var devNamespace = "retry-final-order"
+	var managedNamespace = "retry-final-order-managed"
+	var _ *appservice.Snapshot
+	var sampleImage = "quay.io/hacbs-release-tests/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+	var ecPolicyName = "retry-final-order-policy-" + utils.GenerateRandomString(4)
+
+	var releaseCR *releaseApi.Release
+
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework: %v", err)
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s: %v", managedNamespace, err)
+
+		managedServiceAccount, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, managedNamespace, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", constants.ReleasePipelineServiceAccountDefault, managedNamespace, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding: %v", err)
+
+		releasePublicKeyDecoded := []byte("-----BEGIN PUBLIC KEY-----\n" +
+			"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEocSG/SnE0vQ20wRfPltlXrY4Ib9B\n" +
+			"CRnFUCg/fndZsXdz0IX5sfzIyspizaTbu4rapV85KirmSBU6XUaLY347xg==\n" +
+			"-----END PUBLIC KEY-----")
+		err = fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(releasePublicKeyDecoded, constants.PublicSecretNameAuth, managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create signing secret %s: %v", constants.PublicSecretNameAuth, err)
+
+		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		gomega.Expect(defaultEcPolicy.Spec.Sources).ToNot(gomega.BeEmpty(), "default EC policy has no sources")
+
+		source := defaultEcPolicy.Spec.Sources[0]
+		source.Config = &ecp.SourceConfig{
+			Include: []string{"@slsa3"},
+			Exclude: []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+		}
+
+		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
+			Description: "Red Hat's enterprise requirements",
+			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, constants.PublicSecretNameAuth),
+			Sources:     []ecp.Source{source},
+		}
+		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)
+
+		// Delete any existing ReleaseServiceConfig and create a new one with the desired RetryablePipeline configuration.
+		_ = fw.AsKubeAdmin.ReleaseController.DeleteReleaseServiceConfig(releaseApi.ReleaseServiceConfigResourceName, "release-service")
+		err = fw.AsKubeAdmin.ReleaseController.CreateReleaseServiceConfig(
+			releaseApi.ReleaseServiceConfigResourceName, "release-service", []releaseApi.RetryablePipeline{
+				{
+					Url:        releasecommon.RelSvcOperatorURL,
+					Revision:   releasecommon.RelSvcOperatorRevision,
+					PathInRepo: "e2e-tests/pipelines/retry-e2e-managed.yaml",
+					RetryPolicy: releaseApi.RetryPolicy{
+						MaxRetries: 3,
+						Mitigations: &releaseApi.Mitigations{
+							OOMKill: &releaseApi.MemoryMitigation{
+								Multiplier: "2.0",
+								MaxComputeResources: &corev1.ResourceRequirements{
+									Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+								},
+							},
+							Timeout: &releaseApi.TimeoutMitigation{
+								Task: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+								},
+								Pipeline: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 20 * time.Minute},
+								},
+							},
+						},
+					},
+				},
+			})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleaseServiceConfig: %v", err)
+
+		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+		finalPipeline := &tektonutils.ParameterizedPipeline{
+			Pipeline: tektonutils.Pipeline{
+				PipelineRef: tektonutils.PipelineRef{
+					Resolver: "git",
+					Params: []tektonutils.Param{
+						{Name: "url", Value: releasecommon.RelSvcOperatorURL},
+						{Name: "revision", Value: releasecommon.RelSvcOperatorRevision},
+						{Name: "pathInRepo", Value: "e2e-tests/pipelines/simple-e2e-pipeline.yaml"},
+					},
+					UseEmptyDir: true,
+				},
+			},
+		}
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(
+			constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault,
+			managedNamespace, "", nil, nil, finalPipeline, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
+
+		data, err := json.Marshal(map[string]interface{}{
+			"failMode":   "oom",
+			"failOnTask": "task-02",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RPA data: %v", err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(
+			constants.TargetReleasePlanAdmissionName, managedNamespace, "",
+			devNamespace, ecPolicyName, constants.ReleasePipelineServiceAccountDefault,
+			[]string{constants.ApplicationNameDefault}, false,
+			&tektonutils.PipelineRef{
+				Resolver: "git",
+				Params: []tektonutils.Param{
+					{Name: "url", Value: releasecommon.RelSvcOperatorURL},
+					{Name: "revision", Value: releasecommon.RelSvcOperatorRevision},
+					{Name: "pathInRepo", Value: "e2e-tests/pipelines/retry-e2e-managed.yaml"},
+				},
+			},
+			&runtime.RawExtension{Raw: data},
+			nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", constants.TargetReleasePlanAdmissionName, err)
+
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(
+			constants.ComponentName, constants.ApplicationNameDefault, devNamespace,
+			sampleImage, constants.GitSourceComponentUrl, gitSourceRevision, "", "", "", "")
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("Post-release verification", func() {
+
+		ginkgo.It("verifies that a Release CR should have been created in the dev namespace", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				return err
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that a managed PipelineRun is triggered", func() {
+			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForPipelineRunToStart(releaseCR, managedNamespace)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies the Release is marked as succeeded after managed pipeline retries and final pipeline runs", func() {
+			releaseCR, err = fw.AsKubeAdmin.ReleaseController.WaitForRelease(releaseCR)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "expected release %s/%s to succeed", releaseCR.GetNamespace(), releaseCR.GetName())
+		})
+
+		ginkgo.It("verifies the final pipeline ran only after managed pipeline retries completed", func() {
+			gomega.Expect(framework.GetManagedPipelineRetryCount(releaseCR)).To(gomega.Equal(1), "expected exactly one retry of the managed pipeline")
+
+			attempts := releaseCR.Status.ManagedPipelineAttempts
+			gomega.Expect(attempts[0].FailureReason).To(gomega.Equal("OOMKill"), "expected OOMKill failure reason, got %s", attempts[0].FailureReason)
+
+			// Final pipeline PipelineRun was created and present in status.
+			gomega.Expect(releaseCR.Status.FinalProcessing.PipelineRun).NotTo(gomega.BeEmpty(), "expected final pipeline PipelineRun to be present in release status")
+
+			// Verify the final pipeline did not start until the last managed pipeline attempt had finished.
+			lastAttempt := attempts[len(attempts)-1]
+			gomega.Expect(lastAttempt.CompletionTime).NotTo(gomega.BeNil(), "expected last managed attempt to have a completion time")
+			gomega.Expect(releaseCR.Status.FinalProcessing.StartTime).NotTo(gomega.BeNil(), "expected final pipeline to have a start time")
+
+			// Use greater than or equal to because the final pipeline can start within the same second that the last managed attempt completes.
+			gomega.Expect(releaseCR.Status.FinalProcessing.StartTime.Time).To(gomega.BeTemporally(">=", lastAttempt.CompletionTime.Time),
+				"expected final pipeline start %v to be at or after last managed attempt completion %v", releaseCR.Status.FinalProcessing.StartTime, lastAttempt.CompletionTime)
+
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/managed_pipeline_task_timeout_retry.go
+++ b/e2e-tests/tests/release/service/managed_pipeline_task_timeout_retry.go
@@ -1,0 +1,177 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	ecp "github.com/conforma/crds/api/v1alpha1"
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+)
+
+var _ = ginkgo.Describe("Managed pipeline is retried when task timeout is encountered with timeout mitigation", releasecommon.LabelManagedPipelineTaskTimeoutRetry, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+	var err error
+	var devNamespace = "retry-task-timeout"
+	var managedNamespace = "retry-task-timeout-managed"
+	var _ *appservice.Snapshot
+	var sampleImage = "quay.io/hacbs-release-tests/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+	var ecPolicyName = "retry-task-timeout-policy-" + utils.GenerateRandomString(4)
+
+	var releaseCR *releaseApi.Release
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework: %v", err)
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s: %v", managedNamespace, err)
+
+		managedServiceAccount, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, managedNamespace, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", constants.ReleasePipelineServiceAccountDefault, managedNamespace, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding: %v", err)
+
+		releasePublicKeyDecoded := []byte("-----BEGIN PUBLIC KEY-----\n" +
+			"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEocSG/SnE0vQ20wRfPltlXrY4Ib9B\n" +
+			"CRnFUCg/fndZsXdz0IX5sfzIyspizaTbu4rapV85KirmSBU6XUaLY347xg==\n" +
+			"-----END PUBLIC KEY-----")
+		err = fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(releasePublicKeyDecoded, constants.PublicSecretNameAuth, managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create signing secret %s: %v", constants.PublicSecretNameAuth, err)
+
+		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		gomega.Expect(defaultEcPolicy.Spec.Sources).ToNot(gomega.BeEmpty(), "default EC policy has no sources")
+
+		source := defaultEcPolicy.Spec.Sources[0]
+		source.Config = &ecp.SourceConfig{
+			Include: []string{"@slsa3"},
+			Exclude: []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+		}
+
+		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
+			Description: "Red Hat's enterprise requirements",
+			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, constants.PublicSecretNameAuth),
+			Sources:     []ecp.Source{source},
+		}
+		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)
+
+		// Delete any existing ReleaseServiceConfig and create a new one with the desired RetryablePipeline configuration.
+		_ = fw.AsKubeAdmin.ReleaseController.DeleteReleaseServiceConfig(releaseApi.ReleaseServiceConfigResourceName, "release-service")
+		err = fw.AsKubeAdmin.ReleaseController.CreateReleaseServiceConfig(
+			releaseApi.ReleaseServiceConfigResourceName, "release-service", []releaseApi.RetryablePipeline{
+				{
+					Url:        releasecommon.RelSvcOperatorURL,
+					Revision:   releasecommon.RelSvcOperatorRevision,
+					PathInRepo: "e2e-tests/pipelines/retry-e2e-managed.yaml",
+					RetryPolicy: releaseApi.RetryPolicy{
+						MaxRetries: 3,
+						Mitigations: &releaseApi.Mitigations{
+							OOMKill: &releaseApi.MemoryMitigation{
+								Multiplier: "2.0",
+								MaxComputeResources: &corev1.ResourceRequirements{
+									Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+								},
+							},
+							Timeout: &releaseApi.TimeoutMitigation{
+								Task: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+								},
+								Pipeline: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 20 * time.Minute},
+								},
+							},
+						},
+					},
+				},
+			})
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleaseServiceConfig: %v", err)
+
+		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
+
+		data, err := json.Marshal(map[string]interface{}{
+			"failMode":   "task-timeout",
+			"failOnTask": "task-01",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RPA data: %v", err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(constants.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, constants.ReleasePipelineServiceAccountDefault, []string{constants.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
+			Resolver: "git",
+			Params: []tektonutils.Param{
+				{Name: "url", Value: releasecommon.RelSvcOperatorURL},
+				{Name: "revision", Value: releasecommon.RelSvcOperatorRevision},
+				{Name: "pathInRepo", Value: "e2e-tests/pipelines/retry-e2e-managed.yaml"},
+			},
+		}, &runtime.RawExtension{
+			Raw: data,
+		}, nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", constants.TargetReleasePlanAdmissionName, err)
+
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(constants.ComponentName, constants.ApplicationNameDefault, devNamespace, sampleImage, constants.GitSourceComponentUrl, gitSourceRevision, "", "", "", "")
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("Post-release verification", func() {
+
+		ginkgo.It("verifies that a Release CR should have been created in the dev namespace", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				return err
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that a managed PipelineRun is triggered", func() {
+			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForPipelineRunToStart(releaseCR, managedNamespace)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies the Release is marked as succeeded", func() {
+			releaseCR, err = fw.AsKubeAdmin.ReleaseController.WaitForRelease(releaseCR)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "expected release %s/%s to succeed", releaseCR.GetNamespace(), releaseCR.GetName())
+		})
+
+		ginkgo.It("verifies the Release is marked as succeeded with a task timeout mitigation applied", func() {
+			gomega.Expect(framework.GetManagedPipelineRetryCount(releaseCR)).To(gomega.Equal(1), "expected exactly one retry")
+
+			attempts := releaseCR.Status.ManagedPipelineAttempts
+			gomega.Expect(attempts[0].FailureReason).To(gomega.Equal("TaskRunTimeout"), "expected TaskRunTimeout failure reason, got %s", attempts[0].FailureReason)
+
+			lastAttempt := attempts[len(attempts)-1]
+			gomega.Expect(lastAttempt.Mitigation).NotTo(gomega.BeNil(), "expected task timeout mitigation to be recorded")
+			gomega.Expect(lastAttempt.Mitigation.TaskTimeout).NotTo(gomega.BeEmpty(), "expected TasksTimeout to be set by mitigation")
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/managed_pipeline_taskrunspecs_oom_retry.go
+++ b/e2e-tests/tests/release/service/managed_pipeline_taskrunspecs_oom_retry.go
@@ -1,0 +1,200 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	ecp "github.com/conforma/crds/api/v1alpha1"
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	releaseApi "github.com/konflux-ci/release-service/api/v1alpha1"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/release-service/e2e-tests/pkg/utils"
+	releasecommon "github.com/konflux-ci/release-service/e2e-tests/tests/release"
+	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+)
+
+var _ = ginkgo.Describe("Managed pipeline OOM on RPA TaskRunSpecs override is retried with memory mitigation", releasecommon.LabelManagedPipelineTaskRunSpecsOOMRetry, ginkgo.Ordered, func() {
+	defer ginkgo.GinkgoRecover()
+
+	var fw *framework.Framework
+	ginkgo.AfterEach(framework.ReportFailure(&fw))
+	var err error
+	var devNamespace = "retry-taskrunspecs-oom"
+	var managedNamespace = "retry-taskrunspecs-oom-managed"
+	var _ *appservice.Snapshot
+	var sampleImage = "quay.io/hacbs-release-tests/dcmetromap@sha256:544259be8bcd9e6a2066224b805d854d863064c9b64fa3a87bfcd03f5b0f28e6"
+	var gitSourceRevision = "d49914874789147eb2de9bb6a12cd5d150bfff92"
+	var ecPolicyName = "retry-taskrunspecs-oom-policy-" + utils.GenerateRandomString(4)
+
+	var releaseCR *releaseApi.Release
+
+	ginkgo.BeforeAll(func() {
+		fw, err = framework.NewFramework(utils.GetGeneratedNamespace(devNamespace))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create framework: %v", err)
+		devNamespace = fw.UserNamespace
+
+		_, err = fw.AsKubeAdmin.CommonController.CreateTestNamespace(managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create managed namespace %s: %v", managedNamespace, err)
+
+		managedServiceAccount, err := fw.AsKubeAdmin.CommonController.CreateServiceAccount(constants.ReleasePipelineServiceAccountDefault, managedNamespace, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create service account %s in %s: %v", constants.ReleasePipelineServiceAccountDefault, managedNamespace, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create RoleBinding: %v", err)
+
+		releasePublicKeyDecoded := []byte("-----BEGIN PUBLIC KEY-----\n" +
+			"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEocSG/SnE0vQ20wRfPltlXrY4Ib9B\n" +
+			"CRnFUCg/fndZsXdz0IX5sfzIyspizaTbu4rapV85KirmSBU6XUaLY347xg==\n" +
+			"-----END PUBLIC KEY-----")
+		err = fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(releasePublicKeyDecoded, constants.PublicSecretNameAuth, managedNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create signing secret %s: %v", constants.PublicSecretNameAuth, err)
+
+		defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get default EC policy: %v", err)
+		gomega.Expect(defaultEcPolicy.Spec.Sources).ToNot(gomega.BeEmpty(), "default EC policy has no sources")
+
+		source := defaultEcPolicy.Spec.Sources[0]
+		source.Config = &ecp.SourceConfig{
+			Include: []string{"@slsa3"},
+			Exclude: []string{"step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+		}
+
+		defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
+			Description: "Red Hat's enterprise requirements",
+			PublicKey:   fmt.Sprintf("k8s://%s/%s", managedNamespace, constants.PublicSecretNameAuth),
+			Sources:     []ecp.Source{source},
+		}
+		_, err = fw.AsKubeAdmin.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create EC policy %s: %v", ecPolicyName, err)
+
+		// Delete any existing ReleaseServiceConfig and create a new one with the desired RetryablePipeline configuration.
+		_ = fw.AsKubeAdmin.ReleaseController.DeleteReleaseServiceConfig(releaseApi.ReleaseServiceConfigResourceName, "release-service")
+		err = fw.AsKubeAdmin.ReleaseController.CreateReleaseServiceConfig(
+			releaseApi.ReleaseServiceConfigResourceName, "release-service", []releaseApi.RetryablePipeline{
+				{
+					Url:        releasecommon.RelSvcOperatorURL,
+					Revision:   releasecommon.RelSvcOperatorRevision,
+					PathInRepo: "e2e-tests/pipelines/retry-e2e-managed.yaml",
+					RetryPolicy: releaseApi.RetryPolicy{
+						MaxRetries: 3,
+						Mitigations: &releaseApi.Mitigations{
+							OOMKill: &releaseApi.MemoryMitigation{
+								Multiplier: "2.0",
+								MaxComputeResources: &corev1.ResourceRequirements{
+									Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+									Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+								},
+							},
+							Timeout: &releaseApi.TimeoutMitigation{
+								Task: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+								},
+								Pipeline: &releaseApi.TimeoutIncrement{
+									Increment:  metav1.Duration{Duration: 5 * time.Minute},
+									MaxTimeout: &metav1.Duration{Duration: 20 * time.Minute},
+								},
+							},
+						},
+					},
+				},
+			})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleaseServiceConfig: %v", err)
+
+		_, err = fw.AsKubeAdmin.KonfluxApiController.CreateApplication(constants.ApplicationNameDefault, devNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create Application %s: %v", constants.ApplicationNameDefault, err)
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(constants.SourceReleasePlanName, devNamespace, constants.ApplicationNameDefault, managedNamespace, "", nil, nil, nil, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlan %s: %v", constants.SourceReleasePlanName, err)
+
+		data, err := json.Marshal(map[string]interface{}{
+			"failMode":   "oom",
+			"failOnTask": "task-01",
+		})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to marshal RPA data: %v", err)
+
+		taskRunSpecs := []tektonv1.PipelineTaskRunSpec{
+			{
+				PipelineTaskName: "task-01",
+				StepSpecs: []tektonv1.TaskRunStepSpec{
+					{
+						Name: "task-01-step-01",
+						ComputeResources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("40Mi")},
+							Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("40Mi")},
+						},
+					},
+				},
+			},
+		}
+
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(
+			constants.TargetReleasePlanAdmissionName, managedNamespace, "",
+			devNamespace, ecPolicyName, constants.ReleasePipelineServiceAccountDefault,
+			[]string{constants.ApplicationNameDefault}, false,
+			&tektonutils.PipelineRef{
+				Resolver: "git",
+				Params: []tektonutils.Param{
+					{Name: "url", Value: releasecommon.RelSvcOperatorURL},
+					{Name: "revision", Value: releasecommon.RelSvcOperatorRevision},
+					{Name: "pathInRepo", Value: "e2e-tests/pipelines/retry-e2e-managed.yaml"},
+				},
+			},
+			&runtime.RawExtension{Raw: data},
+			nil, taskRunSpecs, nil)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", constants.TargetReleasePlanAdmissionName, err)
+
+		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithImageSource(
+			constants.ComponentName, constants.ApplicationNameDefault, devNamespace,
+			sampleImage, constants.GitSourceComponentUrl, gitSourceRevision, "", "", "", "")
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "failed to create Snapshot: %v", err)
+	})
+
+	ginkgo.AfterAll(func() {
+		if !ginkgo.CurrentSpecReport().Failed() {
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(managedNamespace)).To(gomega.Succeed())
+			gomega.Expect(fw.AsKubeAdmin.CommonController.DeleteNamespace(fw.UserNamespace)).To(gomega.Succeed())
+		}
+	})
+
+	var _ = ginkgo.Describe("Post-release verification", func() {
+
+		ginkgo.It("verifies that a Release CR should have been created in the dev namespace", func() {
+			gomega.Eventually(func() error {
+				releaseCR, err = fw.AsKubeAdmin.ReleaseController.GetFirstReleaseInNamespace(devNamespace)
+				return err
+			}, constants.ReleaseCreationTimeout, constants.DefaultInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies that a managed PipelineRun is triggered", func() {
+			gomega.Expect(fw.AsKubeAdmin.TektonController.WaitForPipelineRunToStart(releaseCR, managedNamespace)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("verifies the Release is marked as succeeded", func() {
+			releaseCR, err = fw.AsKubeAdmin.ReleaseController.WaitForRelease(releaseCR)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "expected release %s/%s to succeed", releaseCR.GetNamespace(), releaseCR.GetName())
+		})
+
+		ginkgo.It("verifies the Release is marked as succeeded with a memory mitigation applied to the RPA TaskRunSpecs override", func() {
+			gomega.Expect(framework.GetManagedPipelineRetryCount(releaseCR)).To(gomega.Equal(2), "expected exactly two retries")
+
+			attempts := releaseCR.Status.ManagedPipelineAttempts
+			gomega.Expect(attempts[0].FailureReason).To(gomega.Equal("OOMKill"), "expected OOMKill failure reason, got %s", attempts[0].FailureReason)
+			gomega.Expect(attempts[1].FailureReason).To(gomega.Equal("OOMKill"), "expected OOMKill failure reason, got %s", attempts[1].FailureReason)
+
+			lastAttempt := attempts[len(attempts)-1]
+			gomega.Expect(lastAttempt.Mitigation).NotTo(gomega.BeNil(), "expected memory mitigation to be recorded")
+			gomega.Expect(lastAttempt.Mitigation.MemoryLimit).NotTo(gomega.BeEmpty(), "expected MemoryLimit to be set by mitigation")
+		})
+	})
+})

--- a/e2e-tests/tests/release/service/missing_release_plan_and_admission.go
+++ b/e2e-tests/tests/release/service/missing_release_plan_and_admission.go
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("Release CR fails when missing ReleasePlan and ReleasePl
 				{Name: "revision", Value: releasecommon.RelSvcCatalogRevision},
 				{Name: "pathInRepo", Value: "pipelines/managed/e2e/e2e.yaml"},
 			},
-		}, nil)
+		}, nil, nil, nil, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s", destinationReleasePlanAdmissionName)
 
 		_, err = fw.AsKubeAdmin.ReleaseController.CreateRelease(releaseName, devNamespace, snapshotName, constants.SourceReleasePlanName)

--- a/e2e-tests/tests/release/service/pipeline_creation_error_surfaced.go
+++ b/e2e-tests/tests/release/service/pipeline_creation_error_surfaced.go
@@ -124,7 +124,7 @@ var _ = ginkgo.Describe("Managed PipelineRun creation denial is surfaced on Rele
 			},
 		}, &runtime.RawExtension{
 			Raw: data,
-		})
+		}, nil, nil, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s: %v", constants.TargetReleasePlanAdmissionName, err)
 
 		_, err = fw.AsKubeAdmin.CommonController.CreateRole("role-release-service-account", managedNamespace, map[string][]string{

--- a/e2e-tests/tests/release/service/release_plan_and_admission_matched.go
+++ b/e2e-tests/tests/release/service/release_plan_and_admission_matched.go
@@ -75,7 +75,7 @@ var _ = ginkgo.Describe("ReleasePlan and ReleasePlanAdmission match", releasecom
 					{Name: "revision", Value: releasecommon.RelSvcCatalogRevision},
 					{Name: "pathInRepo", Value: "pipelines/managed/e2e/e2e.yaml"},
 				},
-			}, nil)
+			}, nil, nil, nil, nil)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create ReleasePlanAdmission %s in %s", constants.TargetReleasePlanAdmissionName, managedNamespace)
 		})
 

--- a/e2e-tests/tests/release/testdata.go
+++ b/e2e-tests/tests/release/testdata.go
@@ -11,15 +11,24 @@ import (
 
 // Test suite labels for release-service e2e tests.
 var (
-	LabelReleaseService                      = ginkgo.Label("release-service")
-	LabelHappyPath                           = ginkgo.Label("release-service", "happy-path")
-	LabelTenant                              = ginkgo.Label("release-service", "tenant")
-	LabelReleasePlanAdm                      = ginkgo.Label("release-service", "release_plan_and_admission")
-	LabelNegative                            = ginkgo.Label("release-service", "release-neg", "negMissingReleasePlan")
-	LabelNegBlockReleases                    = ginkgo.Label("release-service", "release-neg", "negBlockReleases")
-	LabelNegManagedPipelineRunCreationDenied = ginkgo.Label("release-service", "release-neg", "negManagedPipelineRunCreationDenied")
-	LabelNegTenantPipelineInvalidGitRef      = ginkgo.Label("release-service", "release-neg", "negTenantPipelineInvalidGitRef")
-	LabelFinal                               = ginkgo.Label("release-service", "final")
+	LabelReleaseService                            = ginkgo.Label("release-service")
+	LabelHappyPath                                 = ginkgo.Label("release-service", "happy-path")
+	LabelTenant                                    = ginkgo.Label("release-service", "tenant")
+	LabelReleasePlanAdm                            = ginkgo.Label("release-service", "release_plan_and_admission")
+	LabelNegative                                  = ginkgo.Label("release-service", "release-neg", "negMissingReleasePlan")
+	LabelNegBlockReleases                          = ginkgo.Label("release-service", "release-neg", "negBlockReleases")
+	LabelNegManagedPipelineRunCreationDenied       = ginkgo.Label("release-service", "release-neg", "negManagedPipelineRunCreationDenied")
+	LabelManagedPipelineOOMRetry                   = ginkgo.Label("release-service", "retry-managed", "managed-pipeline-oom-retry")
+	LabelManagedPipelineTaskTimeoutRetry           = ginkgo.Label("release-service", "retry-managed", "managed-pipeline-task-timeout-retry")
+	LabelManagedPipelinePipelineTimeoutRetry       = ginkgo.Label("release-service", "retry-managed", "managed-pipeline-pipeline-timeout-retry")
+	LabelManagedPipelineErrorNoRetry               = ginkgo.Label("release-service", "retry-managed", "managed-pipeline-error-no-retry")
+	LabelManagedPipelineMaxRetriesZero             = ginkgo.Label("release-service", "retry-managed", "managed-pipeline-max-retries-zero")
+	LabelManagedPipelineTaskRunSpecsOOMRetry       = ginkgo.Label("release-service", "retry-managed", "managed-pipeline-taskrunspecs-oom-retry")
+	LabelManagedPipelineRetryFinalPipelineOrdering = ginkgo.Label("release-service", "retry-managed", "managed-pipeline-retry-final-pipeline-ordering")
+	LabelManagedPipelineDisabledByTagNoRetry       = ginkgo.Label("release-service", "retry-managed", "managed-pipeline-disabled-by-tag-no-retry")
+	LabelManagedPipelineRetryExhausted             = ginkgo.Label("release-service", "retry-managed", "managed-pipeline-retry-exhausted")
+	LabelNegTenantPipelineInvalidGitRef            = ginkgo.Label("release-service", "release-neg", "negTenantPipelineInvalidGitRef")
+	LabelFinal                                     = ginkgo.Label("release-service", "final")
 )
 
 // ManagednamespaceSecret contains the secrets required for the managed namespace.
@@ -30,6 +39,8 @@ var ManagednamespaceSecret = []corev1.ObjectReference{
 
 // Pipeline configuration variables (loaded from environment at runtime).
 var (
-	RelSvcCatalogURL      string = utils.GetEnv("RELEASE_SERVICE_CATALOG_URL", "https://github.com/konflux-ci/release-service-catalog")
-	RelSvcCatalogRevision string = utils.GetEnv("RELEASE_SERVICE_CATALOG_REVISION", "development")
+	RelSvcCatalogURL       string = utils.GetEnv("RELEASE_SERVICE_CATALOG_URL", "https://github.com/konflux-ci/release-service-catalog")
+	RelSvcCatalogRevision  string = utils.GetEnv("RELEASE_SERVICE_CATALOG_REVISION", "development")
+	RelSvcOperatorURL      string = utils.GetEnv("RELEASE_SERVICE_OPERATOR_URL", "https://github.com/konflux-ci/release-service")
+	RelSvcOperatorRevision string = utils.GetEnv("RELEASE_SERVICE_OPERATOR_REVISION", "main")
 )

--- a/retry/mitigations.go
+++ b/retry/mitigations.go
@@ -98,14 +98,36 @@ func ApplyTaskTimeoutMitigation(current *metav1.Duration, pipelineTimeouts *tekt
 	return &metav1.Duration{Duration: newTaskTimeout}, adjustedTimeouts
 }
 
-// ApplyPipelineTimeoutMitigation adds the increment to the pipeline timeout, capping at MaxTimeout.
+// ApplyPipelineTimeoutMitigation adds the increment to the pipeline and tasks timeout, capping at MaxTimeout.
+// Both timeouts share the same MaxTimeout, so a tasks timeout that started lower than the pipeline
+// timeout can end up capped to the same value once both exceed it.
 func ApplyPipelineTimeoutMitigation(current *tektonv1.TimeoutFields, mitigation *v1alpha1.TimeoutIncrement) *tektonv1.TimeoutFields {
 	if mitigation == nil {
 		return current
 	}
 	adjustedTimeouts := copyTimeoutFields(current)
+
 	newPipelineTimeout := addCappedDuration(adjustedTimeouts.Pipeline, mitigation)
 	adjustedTimeouts.Pipeline = &metav1.Duration{Duration: newPipelineTimeout}
+
+	// PipelineRunTimeout fires for both the pipeline timeout and the tasks timeout, so bump tasks
+	// too when it was already set. Leave it unset otherwise.
+	if adjustedTimeouts.Tasks != nil {
+		adjustedTimeouts.Tasks = &metav1.Duration{Duration: addCappedDuration(adjustedTimeouts.Tasks, mitigation)}
+	}
+
+	// Tekton requires pipeline greater than or equal to tasks plus finally (both 0 when not set).
+	// If the capped pipeline no longer satisfies this, extend it by the difference.
+	var tasksDuration, finallyDuration time.Duration
+	if adjustedTimeouts.Tasks != nil {
+		tasksDuration = adjustedTimeouts.Tasks.Duration
+	}
+	if adjustedTimeouts.Finally != nil {
+		finallyDuration = adjustedTimeouts.Finally.Duration
+	}
+	if difference := (tasksDuration + finallyDuration) - adjustedTimeouts.Pipeline.Duration; difference > 0 {
+		adjustedTimeouts.Pipeline.Duration += difference
+	}
 
 	return adjustedTimeouts
 }

--- a/retry/mitigations_test.go
+++ b/retry/mitigations_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Mitigations", func() {
 	})
 
 	Context("ApplyPipelineTimeoutMitigation", func() {
-		It("should add the increment and preserve tasks timeout", func() {
+		It("should add the increment to both pipeline and tasks timeouts", func() {
 			current := &tektonv1.TimeoutFields{
 				Pipeline: &metav1.Duration{Duration: 1 * time.Hour},
 				Tasks:    &metav1.Duration{Duration: 50 * time.Minute},
@@ -214,23 +214,78 @@ var _ = Describe("Mitigations", func() {
 				&v1alpha1.TimeoutIncrement{Increment: metav1.Duration{Duration: 30 * time.Minute}},
 			)
 			Expect(result.Pipeline.Duration).To(Equal(90 * time.Minute))
-			Expect(result.Tasks.Duration).To(Equal(50 * time.Minute))
+			Expect(result.Tasks.Duration).To(Equal(80 * time.Minute))
 		})
 
-		It("should cap at MaxTimeout", func() {
+		It("should leave tasks nil when it wasn't already set", func() {
+			result := retry.ApplyPipelineTimeoutMitigation(
+				&tektonv1.TimeoutFields{Pipeline: &metav1.Duration{Duration: 1 * time.Hour}},
+				&v1alpha1.TimeoutIncrement{Increment: metav1.Duration{Duration: 30 * time.Minute}},
+			)
+			Expect(result.Pipeline.Duration).To(Equal(90 * time.Minute))
+			Expect(result.Tasks).To(BeNil())
+		})
+
+		It("should cap both pipeline and tasks at MaxTimeout with no difference when they cap equally", func() {
 			max := metav1.Duration{Duration: 1 * time.Hour}
 			result := retry.ApplyPipelineTimeoutMitigation(
-				&tektonv1.TimeoutFields{Pipeline: &metav1.Duration{Duration: 50 * time.Minute}},
+				&tektonv1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 50 * time.Minute},
+					Tasks:    &metav1.Duration{Duration: 45 * time.Minute},
+				},
 				&v1alpha1.TimeoutIncrement{Increment: metav1.Duration{Duration: 30 * time.Minute}, MaxTimeout: &max},
 			)
 			Expect(result.Pipeline.Duration).To(Equal(1 * time.Hour))
+			Expect(result.Tasks.Duration).To(Equal(1 * time.Hour))
 		})
 
-		It("should use the increment when current is nil", func() {
+		It("should extend pipeline by the difference when tasks exceed the pipeline limit", func() {
+			result := retry.ApplyPipelineTimeoutMitigation(
+				&tektonv1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 40 * time.Minute},
+					Tasks:    &metav1.Duration{Duration: 50 * time.Minute},
+				},
+				&v1alpha1.TimeoutIncrement{Increment: metav1.Duration{Duration: 10 * time.Minute}},
+			)
+			Expect(result.Tasks.Duration).To(Equal(60 * time.Minute))
+			Expect(result.Pipeline.Duration).To(Equal(60 * time.Minute))
+		})
+
+		It("should extend pipeline by the difference when tasks plus finally exceed the pipeline limit", func() {
+			max := metav1.Duration{Duration: 1 * time.Hour}
+			result := retry.ApplyPipelineTimeoutMitigation(
+				&tektonv1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 50 * time.Minute},
+					Tasks:    &metav1.Duration{Duration: 45 * time.Minute},
+					Finally:  &metav1.Duration{Duration: 10 * time.Minute},
+				},
+				&v1alpha1.TimeoutIncrement{Increment: metav1.Duration{Duration: 30 * time.Minute}, MaxTimeout: &max},
+			)
+			Expect(result.Tasks.Duration).To(Equal(1 * time.Hour))
+			Expect(result.Pipeline.Duration).To(Equal(70 * time.Minute))
+			Expect(result.Finally.Duration).To(Equal(10 * time.Minute))
+		})
+
+		It("should not produce a negative timeout when finally exceeds the capped pipeline timeout", func() {
+			max := metav1.Duration{Duration: 12 * time.Minute}
+			result := retry.ApplyPipelineTimeoutMitigation(
+				&tektonv1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 10 * time.Minute},
+					Finally:  &metav1.Duration{Duration: 30 * time.Minute},
+				},
+				&v1alpha1.TimeoutIncrement{Increment: metav1.Duration{Duration: 5 * time.Minute}, MaxTimeout: &max},
+			)
+			Expect(result.Pipeline.Duration).To(Equal(30 * time.Minute))
+			Expect(result.Tasks).To(BeNil())
+			Expect(result.Finally.Duration).To(Equal(30 * time.Minute))
+		})
+
+		It("should bump pipeline but leave tasks nil when current is nil", func() {
 			result := retry.ApplyPipelineTimeoutMitigation(nil,
 				&v1alpha1.TimeoutIncrement{Increment: metav1.Duration{Duration: 30 * time.Minute}},
 			)
 			Expect(result.Pipeline.Duration).To(Equal(30 * time.Minute))
+			Expect(result.Tasks).To(BeNil())
 		})
 
 		It("should return current when mitigation is nil", func() {


### PR DESCRIPTION

## Summary
Add retry-e2e-managed.yaml to simulate OOM, taskRunTimeout, PiplineRunTimeout and error.

Add simple-e2e-pipeline.yaml for tenant pipeline ordering tests.

Add e2e tests for:
* OOM retries with memory mitigation
* Task timeout retries
* Pipeline timeout retries
* Errors are not retried
* RPA MaxRetries=0 disables retries
* RPA TaskRunSpecs override OOM mitigation
* Final pipeline waits for retries to complete
* Retries disabled when a production tag matches
* Release fails once all retries are exhausted

**Fix pipeline timeout mitigation to also increase tasks timeout. A PipelineRun can fail on either one for PipelineRunTimeout, so updating only the pipeline timeout may cause the same failure. Also ensure pipeline timeout remains valid when tasks + finally would exceed it.**

Assisted-by: Claude
Signed-off-by: Sean Conroy <sconroy@redhat.com>

## Related Issues
[RELEASE-2683](https://redhat.atlassian.net/browse/RELEASE-2683)
Fixes #

## Testing

- [x] Tests added/updated
- [x] All tests pass (`make test`)
- [x] Changes verified locally

## Checklist

- [x] Code follows Kubernetes coding conventions
- [x] Commit messages follow conventional format: `type(RELEASE-NNNN): description`
- [x] Documentation updated if needed
- [x] Generated manifests updated (`make manifests generate`)


[RELEASE-2683]: https://redhat.atlassian.net/browse/RELEASE-2683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ