### PR TITLE
chore: add controller promotion checklist to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,12 @@ Fixes #
 - [ ] Commit messages follow conventional format: `type(RELEASE-NNNN): description`
 - [ ] Documentation updated if needed
 - [ ] Generated manifests updated (`make manifests generate`)
+
+## Controller Promotion (skip if this is a Mintmaker/bot PR)
+
+Once your infra-deployments development PR is merged, you are responsible for
+promoting the release-service controller to staging and production.
+
+- [ ] Infra-deployments `development` PR merged (automated by pipeline)
+- [ ] Controller promoted to `staging` — [promote-overlay script](https://github.com/konflux-ci/release-service-utils/tree/main/ci/promote-overlay)
+- [ ] Controller promoted to `production` — [promote-overlay script](https://github.com/konflux-ci/release-service-utils/tree/main/ci/promote-overlay)


### PR DESCRIPTION
Add a post-merge controller promotion section for non-Mintmaker contributors as a reminder to run the promote-overlay script to promote the release-service controller to staging and production.

## Summary

<!-- Describe the changes in this PR -->

## Related Issues

Fixes #

## Testing

- [ ] Tests added/updated
- [ ] All tests pass (`make test`)
- [ ] Changes verified locally

## Checklist

- [ ] Code follows Kubernetes coding conventions
- [ ] Commit messages follow conventional format: `type(RELEASE-NNNN): description`
- [ ] Documentation updated if needed
- [ ] Generated manifests updated (`make manifests generate`)
