### PR TITLE
chore(RELEASE-2683): export operator URL and revision in e2e test

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests-pipeline.yaml
@@ -273,6 +273,10 @@ spec:
               export QUAY_TOKEN="$(base64 -d < "${SECRETS}/quay-token")"
               export RELEASE_CATALOG_TA_QUAY_TOKEN="$(base64 -d < "${SECRETS}/release-catalog-ta-quay-token")"
 
+              # Point the retry pipeline git resolver at this PR's repo and commit
+              export RELEASE_SERVICE_OPERATOR_URL="${GIT_URL}"
+              export RELEASE_SERVICE_OPERATOR_REVISION="${GIT_REVISION}"
+
               # Set up a clean working directory
               WORK_DIR="$(mktemp -d)"
               export GOPATH="${WORK_DIR}/go"


### PR DESCRIPTION
## Summary
Export RELEASE_SERVICE_OPERATOR_URL and RELEASE_SERVICE_OPERATOR_REVISION so e2e tests resolve retry pipeline from the PR commit/branch.

Without this the merge queue resolves from main where the newv pipeline YAMLs do not exist yet causing CouldntGetPipeline errors.

Relates to #1919

## Related Issues

Fixes #

## Testing

- [ ] Tests added/updated
- [ ] All tests pass (`make test`)
- [ ] Changes verified locally

## Checklist

- [ ] Code follows Kubernetes coding conventions
- [ ] Commit messages follow conventional format: `type(RELEASE-NNNN): description`
- [ ] Documentation updated if needed
- [ ] Generated manifests updated (`make manifests generate`)
