### PR TITLE
fix(RELEASE-2681): don't hard-fail on network errors with token

### DIFF
--- a/config/manager/network_policy.yaml
+++ b/config/manager/network_policy.yaml
@@ -52,3 +52,105 @@ spec:
       ports:
         - port: 5353
           protocol: UDP
+    # RELEASE-2681: allow HTTPS egress to github.com so ResolveBranchToSHA can
+    # authenticate with GITHUB_TOKEN instead of silently falling back to the
+    # branch name. Full "git" range set from https://api.github.com/meta as of
+    # 2026-09-09 - GitHub rotates the individual /32s over time, so re-fetch
+    # that endpoint and update this list if resolution starts failing again
+    # with a network/TLS error instead of a clean auth response.
+    - to:
+      - ipBlock:
+          cidr: 140.82.112.0/20
+      - ipBlock:
+          cidr: 143.55.64.0/20
+      - ipBlock:
+          cidr: 172.182.252.133/32
+      - ipBlock:
+          cidr: 172.182.252.135/32
+      - ipBlock:
+          cidr: 185.199.108.0/22
+      - ipBlock:
+          cidr: 192.30.252.0/22
+      - ipBlock:
+          cidr: 20.175.192.146/32
+      - ipBlock:
+          cidr: 20.175.192.147/32
+      - ipBlock:
+          cidr: 20.199.39.227/32
+      - ipBlock:
+          cidr: 20.199.39.232/32
+      - ipBlock:
+          cidr: 20.200.245.247/32
+      - ipBlock:
+          cidr: 20.200.245.248/32
+      - ipBlock:
+          cidr: 20.201.28.151/32
+      - ipBlock:
+          cidr: 20.201.28.152/32
+      - ipBlock:
+          cidr: 20.205.243.160/32
+      - ipBlock:
+          cidr: 20.205.243.166/32
+      - ipBlock:
+          cidr: 20.207.73.82/32
+      - ipBlock:
+          cidr: 20.207.73.83/32
+      - ipBlock:
+          cidr: 20.217.135.4/32
+      - ipBlock:
+          cidr: 20.217.135.5/32
+      - ipBlock:
+          cidr: 20.233.83.145/32
+      - ipBlock:
+          cidr: 20.233.83.149/32
+      - ipBlock:
+          cidr: 20.26.156.214/32
+      - ipBlock:
+          cidr: 20.26.156.215/32
+      - ipBlock:
+          cidr: 20.27.177.113/32
+      - ipBlock:
+          cidr: 20.27.177.118/32
+      - ipBlock:
+          cidr: 20.29.134.19/32
+      - ipBlock:
+          cidr: 20.29.134.23/32
+      - ipBlock:
+          cidr: 20.87.245.0/32
+      - ipBlock:
+          cidr: 20.87.245.4/32
+      - ipBlock:
+          cidr: 4.208.26.197/32
+      - ipBlock:
+          cidr: 4.208.26.198/32
+      - ipBlock:
+          cidr: 4.225.11.194/32
+      - ipBlock:
+          cidr: 4.225.11.200/32
+      - ipBlock:
+          cidr: 4.228.31.145/32
+      - ipBlock:
+          cidr: 4.228.31.150/32
+      - ipBlock:
+          cidr: 4.237.22.38/32
+      - ipBlock:
+          cidr: 4.237.22.40/32
+      - ipBlock:
+          cidr: 4.249.131.163/32
+      - ipBlock:
+          cidr: 4.249.131.164/32
+      - ipBlock:
+          cidr: 48.202.248.38/32
+      - ipBlock:
+          cidr: 48.202.248.40/32
+      - ipBlock:
+          cidr: 48.204.201.5/32
+      - ipBlock:
+          cidr: 48.204.201.6/32
+      - ipBlock:
+          cidr: 2606:50c0::/32
+      - ipBlock:
+          cidr: 2a0a:a440::/29
+      ports:
+        - port: 443
+          protocol: TCP

--- a/git/references.go
+++ b/git/references.go
@@ -71,6 +71,18 @@ func IsRateLimitError(err error) bool {
 		strings.Contains(errStr, "403")
 }
 
+// IsAuthenticationError reports whether err is go-git's transport rejecting the
+// request's credentials: HTTP 401 ("authentication required") or HTTP 403
+// ("authorization failed"). See go-git's transport/http.NewErr.
+func IsAuthenticationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "authentication required") ||
+		strings.Contains(errStr, "authorization failed")
+}
+
 // ValidateGitResolverConfig validates the git resolver configuration parameters.
 // Returns ErrInvalidGitResolverConfig if any required parameter is empty or whitespace-only.
 func ValidateGitResolverConfig(url, revision, pathInRepo string) error {

--- a/git/references_test.go
+++ b/git/references_test.go
@@ -78,6 +78,33 @@ var _ = Describe("Git References", func() {
 		})
 	})
 
+	Describe("IsAuthenticationError", func() {
+		It("should return false for nil error", func() {
+			Expect(IsAuthenticationError(nil)).To(BeFalse())
+		})
+
+		It("should return true for HTTP 401 rejections", func() {
+			err := fmt.Errorf("remote repository access failed: authentication required")
+			Expect(IsAuthenticationError(err)).To(BeTrue())
+		})
+
+		It("should return true for HTTP 403 rejections", func() {
+			err := fmt.Errorf("remote repository access failed: authorization failed: Resource not accessible by personal access token")
+			Expect(IsAuthenticationError(err)).To(BeTrue())
+		})
+
+		It("should return false for other errors", func() {
+			err := fmt.Errorf("rate limit exceeded")
+			Expect(IsAuthenticationError(err)).To(BeFalse())
+
+			err = fmt.Errorf("connection refused")
+			Expect(IsAuthenticationError(err)).To(BeFalse())
+
+			err = fmt.Errorf("tls: failed to verify certificate: x509: certificate signed by unknown authority")
+			Expect(IsAuthenticationError(err)).To(BeFalse())
+		})
+	})
+
 	Describe("ResolveBranchToSHA", func() {
 		It("should return SHA directly if input is already a SHA", func() {
 			sha := "1234567890abcdef1234567890abcdef12345678"

--- a/tekton/utils/pipeline_run_builder.go
+++ b/tekton/utils/pipeline_run_builder.go
@@ -242,15 +242,15 @@ func (b *PipelineRunBuilder) WithPipelineRef(pipelineRef *tektonv1.PipelineRef) 
 
 		resolvedSHA, err := git.ResolveBranchToSHA(gitURL, revision)
 		if err != nil {
-			// RELEASE-2681: never fall back on rate limits — that was passing branch names as SHAs.
-			// Also fail when a GitHub token is configured but resolution still fails (bad/expired token).
-			failHard := git.IsRateLimitError(err) || (git.IsGitHubURL(gitURL) && git.HasGitHubToken())
+			isAuthError := git.IsAuthenticationError(err)
+			// Hard-fail only on a rate limit, or an explicit auth rejection with a
+			// GitHub token configured. Any other resolution failure falls back to
+			// the branch name and lets Tekton's own git clone resolve it.
+			failHard := git.IsRateLimitError(err) ||
+				(isAuthError && git.IsGitHubURL(gitURL) && git.HasGitHubToken())
 			canFallback := !failHard &&
-				(strings.Contains(err.Error(), "authentication required") ||
-					strings.Contains(err.Error(), "remote repository access failed"))
+				(isAuthError || strings.Contains(err.Error(), "remote repository access failed"))
 			if canFallback {
-				// RELEASE-1720: private repos / environments where go-git cannot list refs (e.g. kind
-				// clusters with custom TLS CAs) may still resolve via Tekton's git clone.
 				pipelineRunBuilderLog.Info("could not resolve git revision to SHA, using branch name",
 					"url", git.RedactURLCredentials(gitURL), "revision", revision, "error", err.Error())
 				resolvedSHA = revision

--- a/tekton/utils/pipeline_run_builder_test.go
+++ b/tekton/utils/pipeline_run_builder_test.go
@@ -557,6 +557,43 @@ var _ = Describe("PipelineRun builder", func() {
 			Expect(taskGitRevision).To(Equal("main"))
 		})
 
+		It("falls back to the branch name when a GitHub token is set but the failure is a network/TLS error, not auth or a rate limit", func() {
+			// This is the RELEASE-2681 staging regression: a restrictive egress
+			// NetworkPolicy blocked the controller from reaching GitHub at all
+			// (context deadline exceeded / TLS errors), which is not something a
+			// missing or bad token caused. With a GITHUB_TOKEN configured, the
+			// original fix hard-failed here too, which stalled every Release stuck
+			// behind that ReleasePlanAdmission. It must fall back instead.
+			original := git.ResolveBranchToSHA
+			DeferCleanup(func() { git.ResolveBranchToSHA = original })
+			GinkgoT().Setenv(git.GitHubTokenEnvVar, "some-valid-token")
+			git.ResolveBranchToSHA = func(repoURL, revision string) (string, error) {
+				return "", fmt.Errorf("remote repository access failed: Get %q: context deadline exceeded", repoURL)
+			}
+
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			pipelineRef := &PipelineRef{
+				Resolver: "git",
+				Params: []Param{
+					{Name: "url", Value: "https://github.com/org/repo.git"},
+					{Name: "revision", Value: "production"},
+					{Name: "pathInRepo", Value: "pipelines/release.yaml"},
+				},
+			}
+
+			builder.WithPipelineRef(pipelineRef.ToTektonPipelineRef())
+			pipelineRun, err := builder.Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			var taskGitRevision string
+			for _, param := range pipelineRun.Spec.Params {
+				if param.Name == "taskGitRevision" {
+					taskGitRevision = param.Value.StringVal
+				}
+			}
+			Expect(taskGitRevision).To(Equal("production"))
+		})
+
 		It("fails instead of falling back to branch name on rate limit errors", func() {
 			original := git.ResolveBranchToSHA
 			DeferCleanup(func() { git.ResolveBranchToSHA = original })
@@ -605,6 +642,38 @@ var _ = Describe("PipelineRun builder", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("git resolution failed"))
 			Expect(err.Error()).To(ContainSubstring("authentication required"))
+		})
+
+		It("fails when a GitHub token is set but the request is rejected with a non-rate-limit 403", func() {
+			// go-git maps HTTP 403 to "authorization failed" (transport.ErrAuthorizationFailed),
+			// distinct from the 401 "authentication required" case. GitHub returns 403 for
+			// reasons other than rate limiting too (SSO not authorized, a fine-grained PAT
+			// lacking repo access, a blocked/suspended token). None of those responses
+			// necessarily contain "rate limit" or the literal "403" text IsRateLimitError
+			// looks for, so this must still be treated as an explicit rejection and hard-fail,
+			// not be masked by falling back to the branch name.
+			original := git.ResolveBranchToSHA
+			DeferCleanup(func() { git.ResolveBranchToSHA = original })
+			GinkgoT().Setenv(git.GitHubTokenEnvVar, "revoked-token")
+			git.ResolveBranchToSHA = func(repoURL, revision string) (string, error) {
+				return "", fmt.Errorf("remote repository access failed: authorization failed: Resource not accessible by personal access token")
+			}
+
+			builder := NewPipelineRunBuilder("testPrefix", "testNamespace")
+			pipelineRef := &PipelineRef{
+				Resolver: "git",
+				Params: []Param{
+					{Name: "url", Value: "https://github.com/org/repo.git"},
+					{Name: "revision", Value: "production"},
+					{Name: "pathInRepo", Value: "pipelines/release.yaml"},
+				},
+			}
+
+			builder.WithPipelineRef(pipelineRef.ToTektonPipelineRef())
+			_, err := builder.Build()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("git resolution failed"))
+			Expect(err.Error()).To(ContainSubstring("authorization failed"))
 		})
 
 		It("falls back to the branch name on authentication errors when no GitHub token is set", func() {


### PR DESCRIPTION


## Summary

Follow-up to #1753 (RELEASE-2681), which added authenticated GitHub branch→SHA
resolution (`GITHUB_TOKEN`) and made `ResolveBranchToSHA` failures hard-fail
instead of silently falling back, to stop rate-limit exhaustion from passing
raw branch names as SHAs.

That PR caused a staging regression and was rolled back: staging's egress
`NetworkPolicy` does not allow traffic to `github.com`, so `ResolveBranchToSHA`
hit a network-level error on every git-resolver `ReleasePlanAdmission`. The
old `failHard` check treated *any* GitHub-URL failure as fatal once
`GITHUB_TOKEN` was configured, so every one of those releases hard-failed and
stalled instead of falling back to the branch name, until Sean reverted the
deployed image.

This PR:

1. **Narrows `failHard`** to only trigger on a confirmed rate limit or a
   token explicitly rejected as bad/expired. Any other remote-access failure
   (network, DNS, TLS, timeout — including the exact staging case above) now
   falls back to the branch name, same as before `GITHUB_TOKEN` existed.
2. **Adds GitHub's published IP ranges** to the controller's egress
   `NetworkPolicy`, additively.

## Related Issues

Fixes #

## Testing

- [ ] Tests added/updated
- [ ] All tests pass (`make test`)
- [ ] Changes verified locally

## Checklist

- [ ] Code follows Kubernetes coding conventions
- [ ] Commit messages follow conventional format: `type(RELEASE-NNNN): description`
- [ ] Documentation updated if needed
- [ ] Generated manifests updated (`make manifests generate`)

## Controller Promotion (skip if this is a Mintmaker/bot PR)

Once your infra-deployments development PR is merged, you are responsible for
promoting the release-service controller to staging and production.

- [ ] Infra-deployments `development` PR merged (automated by pipeline)
- [ ] Controller promoted to `staging` — [promote-overlay script](https://github.com/konflux-ci/release-service-utils/tree/main/ci/promote-overlay)
- [ ] Controller promoted to `production` — [promote-overlay script](https://github.com/konflux-ci/release-service-utils/tree/main/ci/promote-overlay)
